### PR TITLE
Remove spaces before numbers in order to avoid search errors

### DIFF
--- a/src/Solr/Query/Params/FilterQueryBuilder.php
+++ b/src/Solr/Query/Params/FilterQueryBuilder.php
@@ -153,7 +153,7 @@ class FilterQueryBuilder
      */
     public function buildFilterQuery($storeId, $attributeToReset = '')
     {
-            $filterQuery = 'store_id:' . $storeId;
+            $filterQuery = 'content_type:product AND store_id:' . $storeId;
             if ($this->isCategoryPage) {
                 $filterQuery .= ' AND is_visible_in_catalog_i:1';
             } else {

--- a/src/Solr/Query/SearchString.php
+++ b/src/Solr/Query/SearchString.php
@@ -30,10 +30,15 @@ final class SearchString
         return $this->rawString;
     }
 
+    /**
+     * Remove spaces before numbers in order to avoid search errors
+     *
+     * @return string
+     */
     public function getEscapedString()
     {
         if ($this->escapedString === null) {
-            $this->escapedString = $this->escape($this->getRawString());
+            $this->escapedString = preg_replace('/\s([0-9])/', '$1', $this->escape($this->getRawString()));
         }
         return $this->escapedString;
     }

--- a/src/Solr/Query/SearchString.php
+++ b/src/Solr/Query/SearchString.php
@@ -38,7 +38,7 @@ final class SearchString
     public function getEscapedString()
     {
         if ($this->escapedString === null) {
-            $this->escapedString = preg_replace('/\s([0-9])/', '$1', $this->escape($this->getRawString()));
+            $this->escapedString = preg_replace(['/\s+([0-9])/','/\s+/'], ['$1', ' '], $this->escape($this->getRawString()));
         }
         return $this->escapedString;
     }

--- a/test/Solr/Query/SearchQueryBuilderTest.php
+++ b/test/Solr/Query/SearchQueryBuilderTest.php
@@ -66,7 +66,7 @@ class SearchQueryBuilderTest extends PHPUnit_Framework_TestCase
         $defaultPagination = PaginationStub::defaultPagination();
         $defaultExpectedParams = [
             'q.op' => ResultsConfig::SEARCH_OPERATOR_AND,
-            'fq' => "store_id:$defaultStoreId AND is_visible_in_search_i:1",
+            'fq' => "content_type:product AND store_id:$defaultStoreId AND is_visible_in_search_i:1",
             'fl' => 'result_html_list_nonindex,result_html_grid_nonindex,score,sku_s,name_s,product_id',
             'sort' => 'score desc',
             'facet' => 'true',
@@ -95,7 +95,7 @@ class SearchQueryBuilderTest extends PHPUnit_Framework_TestCase
                 FilterQueryBuilder::noFilterQueryBuilder($defaultResultConfig), PaginationStub::alternativePagination(), new SearchString('"foo bar"'),
                 new Query(1, 'attribute1_t:""foo bar""~100^0 OR attribute2_t:""foo bar""~100^0 OR category_name_t_mv:""foo bar""~100^1', 0, 24, [
                         'q.op' => ResultsConfig::SEARCH_OPERATOR_OR,
-                        'fq' => "store_id:1 AND is_visible_in_search_i:1",
+                        'fq' => "content_type:product AND store_id:1 AND is_visible_in_search_i:1",
                         'sort' => 'attribute1_s desc',
                         'f.price_f.facet.interval.set' => [
                             "(0.000000,10.000000]", "(10.000000,20.000000]", "(20.000000,50.000000]", "(50.000000,100.000000]", "(100.000000,200.000000]",
@@ -111,7 +111,7 @@ class SearchQueryBuilderTest extends PHPUnit_Framework_TestCase
                     ->addPriceRangeFilterByMinMax(13,37),
                 $defaultPagination, new SearchString('foo bar'),
                 new Query($defaultStoreId, 'foo bar~0.7', 0, PaginationStub::DEFAULT_PAGESIZE, [
-                        'fq' => 'store_id:0 AND is_visible_in_search_i:1 AND attribute1_facet:blue AND category:42 AND price_f:[13.000000 TO 37.000000]'
+                        'fq' => 'content_type:product AND store_id:0 AND is_visible_in_search_i:1 AND attribute1_facet:blue AND category:42 AND price_f:[13.000000 TO 37.000000]'
                     ] + $defaultExpectedParams)
             ]
         ];

--- a/test/Solr/Query/SearchQueryBuilderTest.php
+++ b/test/Solr/Query/SearchQueryBuilderTest.php
@@ -91,6 +91,10 @@ class SearchQueryBuilderTest extends PHPUnit_Framework_TestCase
                 FilterQueryBuilder::noFilterQueryBuilder($defaultResultConfig), $defaultPagination, new SearchString('foo bar'),
                 new Query($defaultStoreId, 'foo bar~0.7', 0, PaginationStub::DEFAULT_PAGESIZE, $defaultExpectedParams)
             ],
+            'default_numbers' => [$defaultStoreId, $defaultResultConfig, FuzzyConfigBuilder::defaultConfig()->build(),
+                FilterQueryBuilder::noFilterQueryBuilder($defaultResultConfig), $defaultPagination, new SearchString('foo 1 bar 2'),
+                new Query($defaultStoreId, 'foo1 bar2~0.7', 0, PaginationStub::DEFAULT_PAGESIZE, $defaultExpectedParams)
+            ],
             'alternative' => [1, ResultConfigBuilder::alternativeConfig()->build(), FuzzyConfigBuilder::inactiveConfig()->build(),
                 FilterQueryBuilder::noFilterQueryBuilder($defaultResultConfig), PaginationStub::alternativePagination(), new SearchString('"foo bar"'),
                 new Query(1, 'attribute1_t:""foo bar""~100^0 OR attribute2_t:""foo bar""~100^0 OR category_name_t_mv:""foo bar""~100^1', 0, 24, [

--- a/test/Solr/Query/SearchQueryBuilderTest.php
+++ b/test/Solr/Query/SearchQueryBuilderTest.php
@@ -91,8 +91,12 @@ class SearchQueryBuilderTest extends PHPUnit_Framework_TestCase
                 FilterQueryBuilder::noFilterQueryBuilder($defaultResultConfig), $defaultPagination, new SearchString('foo bar'),
                 new Query($defaultStoreId, 'foo bar~0.7', 0, PaginationStub::DEFAULT_PAGESIZE, $defaultExpectedParams)
             ],
+            'default_spaces' => [$defaultStoreId, $defaultResultConfig, FuzzyConfigBuilder::defaultConfig()->build(),
+                FilterQueryBuilder::noFilterQueryBuilder($defaultResultConfig), $defaultPagination, new SearchString('foo   bar'),
+                new Query($defaultStoreId, 'foo bar~0.7', 0, PaginationStub::DEFAULT_PAGESIZE, $defaultExpectedParams)
+            ],
             'default_numbers' => [$defaultStoreId, $defaultResultConfig, FuzzyConfigBuilder::defaultConfig()->build(),
-                FilterQueryBuilder::noFilterQueryBuilder($defaultResultConfig), $defaultPagination, new SearchString('foo 1 bar 2'),
+                FilterQueryBuilder::noFilterQueryBuilder($defaultResultConfig), $defaultPagination, new SearchString('foo 1 bar   2'),
                 new Query($defaultStoreId, 'foo1 bar2~0.7', 0, PaginationStub::DEFAULT_PAGESIZE, $defaultExpectedParams)
             ],
             'alternative' => [1, ResultConfigBuilder::alternativeConfig()->build(), FuzzyConfigBuilder::inactiveConfig()->build(),


### PR DESCRIPTION
Exact matches for searches like "Omega 3" or "Jura Giga 5" returned no exact results as Solr has problems with numbers. With this PR, we change the search query to "Omega3" or "Jura Giga5", which results in direct matches. 