### PR TITLE
Solr priority for outofstock products

### DIFF
--- a/src/Solr/Config/AutosuggestConfig.php
+++ b/src/Solr/Config/AutosuggestConfig.php
@@ -52,6 +52,10 @@ final class AutosuggestConfig
      * @var mixed[][]
      */
     private $attributeFilterSuggestions;
+    /**
+     * @var bool
+     */
+    private $showOutOfStock;
 
     /**
      * @param bool $active
@@ -63,10 +67,20 @@ final class AutosuggestConfig
      * @param bool $showCompleteCategoryPath
      * @param string $categoryLinkType
      * @param $attributeFilterSuggestions
+     * @param bool $showOutOfStock
      */
-    public function __construct($active, $usePhpFile, $maxNumberSearchwordSuggestions, $maxNumberProductSuggestions,
-                                $maxNumberCategorySuggestions, $maxNumberCmsPageSuggestions, $showCompleteCategoryPath, $categoryLinkType, $attributeFilterSuggestions)
-    {
+    public function __construct(
+        $active,
+        $usePhpFile,
+        $maxNumberSearchwordSuggestions,
+        $maxNumberProductSuggestions,
+        $maxNumberCategorySuggestions,
+        $maxNumberCmsPageSuggestions,
+        $showCompleteCategoryPath,
+        $categoryLinkType,
+        $attributeFilterSuggestions,
+        $showOutOfStock
+    ) {
         $this->active = $active;
         $this->usePhpFile = $usePhpFile;
         $this->maxNumberSearchwordSuggestions = (int)$maxNumberSearchwordSuggestions;
@@ -76,6 +90,7 @@ final class AutosuggestConfig
         $this->showCompleteCategoryPath = $showCompleteCategoryPath;
         $this->categoryLinkType = $categoryLinkType;
         $this->attributeFilterSuggestions = $attributeFilterSuggestions;
+        $this->showOutOfStock = $showOutOfStock;
     }
 
     /**
@@ -150,5 +165,13 @@ final class AutosuggestConfig
     public function getAttributeFilterSuggestions()
     {
         return $this->attributeFilterSuggestions;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isShowOutOfStock()
+    {
+        return $this->showOutOfStock;
     }
 }

--- a/src/Solr/Config/CategoryConfig.php
+++ b/src/Solr/Config/CategoryConfig.php
@@ -46,6 +46,10 @@ final class CategoryConfig
      * @var float
      */
     private $fuzzySensitivity;
+    /**
+     * @var bool
+     */
+    private $showOutOfStock;
 
     /**
      * @param bool $active
@@ -56,7 +60,7 @@ final class CategoryConfig
      * @param bool $isFuzzyActive
      * @param float $fuzzySensitivity
      */
-    public function __construct($active, $filterPosition, $indexerActive, $useInSearchResults, $maxNumberResults, $isFuzzyActive, $fuzzySensitivity)
+    public function __construct($active, $filterPosition, $indexerActive, $useInSearchResults, $maxNumberResults, $isFuzzyActive, $fuzzySensitivity, $showOutOfStock)
     {
         $this->active = $active;
         $this->filterPosition = $filterPosition;
@@ -65,6 +69,7 @@ final class CategoryConfig
         $this->maxNumberResults = $maxNumberResults;
         $this->isFuzzyActive = $isFuzzyActive;
         $this->fuzzySensitivity = $fuzzySensitivity;
+        $this->showOutOfStock = $showOutOfStock;
     }
 
     /**
@@ -123,4 +128,11 @@ final class CategoryConfig
         return $this->fuzzySensitivity;
     }
 
+    /**
+     * @return bool
+     */
+    public function isShowOutOfStock()
+    {
+        return $this->showOutOfStock;
+    }
 }

--- a/src/Solr/Config/ResultsConfig.php
+++ b/src/Solr/Config/ResultsConfig.php
@@ -41,6 +41,10 @@ final class ResultsConfig
      * @var float[]
      */
     private $customPriceIntervals;
+    /**
+     * @var bool
+     */
+    private $showOutOfStock;
 
     /**
      * IntegerNet\Solr\Config\ResultsConfig constructor.
@@ -51,9 +55,18 @@ final class ResultsConfig
      * @param float $maxPrice
      * @param bool $useCustomPriceIntervals
      * @param float[] $customPriceIntervals
+     * @param bool $showOutOfStock
      */
-    public function __construct($useHtmlFromSolr, $searchOperator, $priorityCategories, $priceStepSize, $maxPrice, $useCustomPriceIntervals, array $customPriceIntervals)
-    {
+    public function __construct(
+        $useHtmlFromSolr,
+        $searchOperator,
+        $priorityCategories,
+        $priceStepSize,
+        $maxPrice,
+        $useCustomPriceIntervals,
+        array $customPriceIntervals,
+        $showOutOfStock
+    ) {
         $this->useHtmlFromSolr = $useHtmlFromSolr;
         $this->searchOperator = $searchOperator;
         $this->priorityCategories = $priorityCategories;
@@ -61,6 +74,7 @@ final class ResultsConfig
         $this->maxPrice = $maxPrice;
         $this->useCustomPriceIntervals = $useCustomPriceIntervals;
         $this->customPriceIntervals = $customPriceIntervals;
+        $this->showOutOfStock = $showOutOfStock;
     }
 
     /**
@@ -119,5 +133,11 @@ final class ResultsConfig
         return $this->customPriceIntervals;
     }
 
-
+    /**
+     * @return bool
+     */
+    public function isShowOutOfStock()
+    {
+        return $this->showOutOfStock;
+    }
 }

--- a/src/Solr/Implementor/Product.php
+++ b/src/Solr/Implementor/Product.php
@@ -48,4 +48,6 @@ interface Product
     public function getSearchableAttributeValue(Attribute $attribute);
 
     public function getCategoryIds();
+
+    public function isInStock();
 }

--- a/src/Solr/Indexer/ProductIndexer.php
+++ b/src/Solr/Indexer/ProductIndexer.php
@@ -203,6 +203,7 @@ class ProductIndexer
             'is_visible_in_catalog_i' => $product->isVisibleInCatalog(),
             'is_visible_in_search_i' => $product->isVisibleInSearch(),
             'has_special_price_i' => $product->hasSpecialPrice(),
+            'is_in_stock_i' => $product->isInStock(),
         ));
 
         $this->_addBoostToProductData($product, $productData);

--- a/src/Solr/Query/AbstractParamsBuilder.php
+++ b/src/Solr/Query/AbstractParamsBuilder.php
@@ -148,9 +148,15 @@ abstract class AbstractParamsBuilder implements ParamsBuilder, HasFilter, HasPag
      * @param string $attributeToReset
      * @return string
      */
-    private function getFilterQuery($attributeToReset = '')
+    protected function getFilterQuery($attributeToReset = '')
     {
-        return $this->filterQueryBuilder->buildFilterQuery($this->getStoreId(), $attributeToReset);
+        $filterQuery = $this->filterQueryBuilder->buildFilterQuery($this->getStoreId(), $attributeToReset);
+
+        if (!$this->resultsConfig->isShowOutOfStock()) {
+            $filterQuery .= ' AND -is_in_stock_i:0';
+        }
+
+        return $filterQuery;
     }
 
     /**

--- a/src/Solr/Query/AbstractParamsBuilder.php
+++ b/src/Solr/Query/AbstractParamsBuilder.php
@@ -150,11 +150,9 @@ abstract class AbstractParamsBuilder implements ParamsBuilder, HasFilter, HasPag
      */
     protected function getFilterQuery($attributeToReset = '')
     {
-        $filterQuery = $this->filterQueryBuilder->buildFilterQuery($this->getStoreId(), $attributeToReset);
-
-        if (!$this->resultsConfig->isShowOutOfStock()) {
-            $filterQuery .= ' AND -is_in_stock_i:0';
-        }
+        $filterQuery = $this->filterQueryBuilder
+            ->setShowOutOfStockProducts($this->resultsConfig->isShowOutOfStock())
+            ->buildFilterQuery($this->getStoreId(), $attributeToReset);
 
         return $filterQuery;
     }

--- a/src/Solr/Query/Params/FilterQueryBuilder.php
+++ b/src/Solr/Query/Params/FilterQueryBuilder.php
@@ -7,6 +7,7 @@
  * @copyright  Copyright (c) 2015 integer_net GmbH (http://www.integer-net.de/)
  * @author     Fabian Schmengler <fs@integer-net.de>
  */
+
 namespace IntegerNet\Solr\Query\Params;
 
 use IntegerNet\Solr\Config\ResultsConfig;
@@ -22,6 +23,10 @@ class FilterQueryBuilder
      * @var $isCategoryPage bool
      */
     private $isCategoryPage = false;
+    /**
+     * @var $showOutOfStock bool
+     */
+    private $showOutOfStockProducts = false;
     /**
      * @var $filters array
      */
@@ -48,14 +53,23 @@ class FilterQueryBuilder
         return $this->resultsConfig;
     }
 
-
     /**
-     * @param $isCategoryPage
+     * @param bool $isCategoryPage
      * @return $this
      */
     public function setIsCategoryPage($isCategoryPage)
     {
         $this->isCategoryPage = $isCategoryPage;
+        return $this;
+    }
+
+    /**
+     * @param bool $showOutOfStockProducts
+     * @return $this
+     */
+    public function setShowOutOfStockProducts($showOutOfStockProducts)
+    {
+        $this->showOutOfStockProducts = $showOutOfStockProducts;
         return $this;
     }
 
@@ -141,7 +155,7 @@ class FilterQueryBuilder
         if ($maxPrice) {
             $this->_addFilter('price_f', sprintf('[%f TO %f]', $minPrice, $maxPrice));
         } else {
-            $this->_addFilter('price_f',sprintf('[%f TO *]', $minPrice));
+            $this->_addFilter('price_f', sprintf('[%f TO *]', $minPrice));
         }
         return $this;
     }
@@ -153,29 +167,33 @@ class FilterQueryBuilder
      */
     public function buildFilterQuery($storeId, $attributeToReset = '')
     {
-            $filterQuery = 'content_type:product AND store_id:' . $storeId;
-            if ($this->isCategoryPage) {
-                $filterQuery .= ' AND is_visible_in_catalog_i:1';
-            } else {
-                $filterQuery .= ' AND is_visible_in_search_i:1';
-            }
+        $filterQuery = 'content_type:product AND store_id:' . $storeId;
+        if ($this->isCategoryPage) {
+            $filterQuery .= ' AND is_visible_in_catalog_i:1';
+        } else {
+            $filterQuery .= ' AND is_visible_in_search_i:1';
+        }
 
-            foreach($this->filters as $attributeCode => $value) {
-                if ($attributeCode == $attributeToReset) {
-                    continue;
-                }
-                if (is_array($value)) {
-                    $filterQuery .= ' AND (';
-                    $filterQueryParts = array();
-                    foreach($value as $singleValue) {
-                        $filterQueryParts[] = $attributeCode . ':' . $singleValue;
-                    }
-                    $filterQuery .= implode(' OR ', $filterQueryParts);
-                    $filterQuery .= ')';
-                } else {
-                    $filterQuery .= ' AND ' . $attributeCode . ':' . $value;
-                }
+        foreach ($this->filters as $attributeCode => $value) {
+            if ($attributeCode == $attributeToReset) {
+                continue;
             }
+            if (is_array($value)) {
+                $filterQuery .= ' AND (';
+                $filterQueryParts = array();
+                foreach ($value as $singleValue) {
+                    $filterQueryParts[] = $attributeCode . ':' . $singleValue;
+                }
+                $filterQuery .= implode(' OR ', $filterQueryParts);
+                $filterQuery .= ')';
+            } else {
+                $filterQuery .= ' AND ' . $attributeCode . ':' . $value;
+            }
+        }
+
+        if (!$this->showOutOfStockProducts) {
+            $filterQuery .= ' AND -is_in_stock_i:0';
+        }
 
         return $filterQuery;
     }

--- a/src/Solr/Query/SearchString.php
+++ b/src/Solr/Query/SearchString.php
@@ -32,13 +32,15 @@ final class SearchString
 
     /**
      * Remove spaces before numbers in order to avoid search errors
+     * Remove all dashes
      *
      * @return string
      */
     public function getEscapedString()
     {
         if ($this->escapedString === null) {
-            $this->escapedString = preg_replace(['/\s+([0-9])/','/\s+/'], ['$1', ' '], $this->escape($this->getRawString()));
+            $this->escapedString = str_replace('-', ' ', $this->escape($this->getRawString()));
+            $this->escapedString = preg_replace(['/\s+([0-9])/','/\s+/'], ['$1', ' '], $this->escapedString);
         }
         return $this->escapedString;
     }

--- a/src/Solr/Util/Version.php
+++ b/src/Solr/Util/Version.php
@@ -11,7 +11,7 @@ namespace IntegerNet\Solr\Util;
 
 class Version
 {
-    const VERSION = '2.0.0';
+    const VERSION = '3.0.0';
 
     static public function getVersion()
     {

--- a/test/Solr/Config/Stub/AutosuggestConfigBuilder.php
+++ b/test/Solr/Config/Stub/AutosuggestConfigBuilder.php
@@ -23,6 +23,7 @@ class AutosuggestConfigBuilder
     private $showCompleteCategoryPath = 0;
     private $categoryLinkType = 'filter';
     private $attributeFilterSuggestions = array();
+    private $showOutOfStock = true;
 
     public static function defaultConfig()
     {
@@ -125,6 +126,6 @@ class AutosuggestConfigBuilder
     {
         return new AutosuggestConfig($this->active, $this->usePhpFile, $this->maxNumberSearchWordSuggestions,
             $this->maxNumberProductSuggestions, $this->maxNumberCategorySuggestions, $this->maxNumberCmsPageSuggestions,
-            $this->showCompleteCategoryPath, $this->categoryLinkType, $this->attributeFilterSuggestions);
+            $this->showCompleteCategoryPath, $this->categoryLinkType, $this->attributeFilterSuggestions, $this->showOutOfStock);
     }
 }

--- a/test/Solr/Config/Stub/CategoryConfigBuilder.php
+++ b/test/Solr/Config/Stub/CategoryConfigBuilder.php
@@ -16,9 +16,14 @@ class CategoryConfigBuilder
     /*
      * Default values
      */
-    private $active = false,
-        $filterPosition = CategoryConfig::FILTER_POSITION_DEFAULT,
-        $indexerActive = false;
+    private $active = false;
+    private $filterPosition = CategoryConfig::FILTER_POSITION_DEFAULT;
+    private $indexerActive = false;
+    private $useInSearchResults = true;
+    private $maxNumberResults = 3;
+    private $isFuzzyActive = true;
+    private $fuzzySensitivity = 0.8;
+    private $showOutOfStock = true;
 
     private function __construct()
     {
@@ -60,6 +65,7 @@ class CategoryConfigBuilder
 
     public function build()
     {
-        return new CategoryConfig($this->active, $this->filterPosition, $this->indexerActive);
+        return new CategoryConfig($this->active, $this->filterPosition, $this->indexerActive, $this->useInSearchResults,
+            $this->maxNumberResults, $this->isFuzzyActive, $this->fuzzySensitivity, $this->showOutOfStock);
     }
 }

--- a/test/Solr/Config/Stub/CmsConfigBuilder.php
+++ b/test/Solr/Config/Stub/CmsConfigBuilder.php
@@ -17,6 +17,10 @@ class CmsConfigBuilder
      * Default values
      */
     private $active = false;
+    private $useInSearchResults = true;
+    private $maxNumberResults = 10;
+    private $isFuzzyActive = true;
+    private $fuzzySensitivity = 0.8;
 
     private function __construct()
     {
@@ -28,6 +32,7 @@ class CmsConfigBuilder
 
    public function build()
     {
-        return new CmsConfig($this->active);
+        return new CmsConfig($this->active, $this->useInSearchResults, $this->maxNumberResults, $this->isFuzzyActive,
+            $this->fuzzySensitivity);
     }
 }

--- a/test/Solr/Config/Stub/ResultConfigBuilder.php
+++ b/test/Solr/Config/Stub/ResultConfigBuilder.php
@@ -44,6 +44,10 @@ class ResultConfigBuilder
      * @var float[]
      */
     private $customPriceIntervals = [10,20,50,100,200,300,400,500];
+    /**
+     * @var bool
+     */
+    private $showOutOfStock = true;
 
     public static function defaultConfig()
     {
@@ -120,6 +124,6 @@ class ResultConfigBuilder
     public function build()
     {
         return new ResultsConfig($this->useCustomPriceIntervals, $this->searchOperator, $this->priorityCategories, $this->priceStepSize,
-            $this->maxPrice, $this->useCustomPriceIntervals, $this->customPriceIntervals);
+            $this->maxPrice, $this->useCustomPriceIntervals, $this->customPriceIntervals, $this->showOutOfStock);
     }
 }

--- a/test/Solr/Query/SearchStringTest.php
+++ b/test/Solr/Query/SearchStringTest.php
@@ -29,12 +29,12 @@ class SearchStringTest extends PHPUnit_Framework_TestCase
         // list taken from http://lucene.apache.org/core/4_4_0/queryparser/org/apache/lucene/queryparser/classic/package-summary.html#package_description
         // which mentions: + - && || ! ( ) { } [ ] ^ " ~ * ? : \ /
         // of which we escape: ( ) { } [ ] ^ " ~ : \ /
-        // and explicitly don't escape: + - && || ! * ?
+        // and explicitly don't escape: + && || ! * ?
         return [
             'single_word' => ['foo', 'foo'],
             'operators' => ['foo +bar', 'foo +bar'],
-            'all_special' => ['+ - && || ! ( ) { } [ ] ^ " ~ * ? : \\ /',
-                '+ - && || ! \( \) \{ \} \[ \] \^ \" \~ * ? \: \\\\ \/'],
+            'all_special' => ['+ && || ! ( ) { } [ ] ^ " ~ * ? : \\ /',
+                '+ && || ! \( \) \{ \} \[ \] \^ \" \~ * ? \: \\\\ \/'],
             'phrase' => ['"multiple words (quoted, can contain "quotes" or \\(escaped\\) characters)"',
                 '"multiple words (quoted, can contain \\"quotes\\" or \\\\(escaped\\\\) characters)"'],
         ];


### PR DESCRIPTION
Show products which are out of stock depending on the configuration for search results, category pages and autosuggest results. Additionally, you can modify the priority of out-of-stock products so they are shown below the other products, setting a new configuration value. This PR belongs to a set of PRs to all related repositories.