### PR TITLE
Avoid Status 100 "continue"

### DIFF
--- a/lib/Apache/Solr/HttpTransport/Curl.php
+++ b/lib/Apache/Solr/HttpTransport/Curl.php
@@ -185,8 +185,8 @@ class Apache_Solr_HttpTransport_Curl extends Apache_Solr_HttpTransport_Abstract
 			// set the post data
 			CURLOPT_POSTFIELDS => $postData,
 
-			// set the content type
-			CURLOPT_HTTPHEADER => array("Content-Type: {$contentType}"),
+			// set the content type; Prevent auto-resume (Status 100 "continue") as it is not supported.
+			CURLOPT_HTTPHEADER => array("Content-Type: {$contentType}", "Expect:"),
 
 			// set the timeout
 			CURLOPT_TIMEOUT => $timeout


### PR DESCRIPTION
I had the problem that indexing sometimes stopped after a few minutes with the message:

```
bin/magento indexer:reindex integernet_solr
IntegerNet_Solr indexer process unknown error:
'100' Status: Continue
```

This fix adjusts the Apache Solr library to not tell the server that it can accept split requests because it doesn't support that.