### PR TITLE
Broaden search result for other sorting than "relevance"

### DIFF
--- a/src/Solr/Query/AbstractParamsBuilder.php
+++ b/src/Solr/Query/AbstractParamsBuilder.php
@@ -49,6 +49,10 @@ abstract class AbstractParamsBuilder implements ParamsBuilder, HasFilter, HasPag
      * @var $eventDispatcher EventDispatcher
      */
     protected $eventDispatcher;
+    /**
+     * @var bool
+     */
+    private $broaden = false;
 
     public function __construct(AttributeRepository $attributeRepository, FilterQueryBuilder $filterQueryBuilder,
                                 Pagination $pagination, ResultsConfig $resultsConfig, FuzzyConfig $fuzzyConfig, $storeId, $eventDispatcher)
@@ -60,6 +64,16 @@ abstract class AbstractParamsBuilder implements ParamsBuilder, HasFilter, HasPag
         $this->fuzzyConfig = $fuzzyConfig;
         $this->storeId = (int) $storeId;
         $this->eventDispatcher = $eventDispatcher;
+    }
+
+    /**
+     * @param boolean $broaden
+     * @return AbstractParamsBuilder
+     */
+    public function setBroaden($broaden)
+    {
+        $this->broaden = $broaden;
+        return $this;
     }
 
     /**
@@ -103,7 +117,7 @@ abstract class AbstractParamsBuilder implements ParamsBuilder, HasFilter, HasPag
 
         $params = $this->addFacetParams($params);
 
-        if (!$this->fuzzyConfig->isActive()) {
+        if (!$this->fuzzyConfig->isActive() || $this->broaden) {
             $params['mm'] = '0%';
         }
         return $params;

--- a/src/Solr/Query/AbstractQueryBuilder.php
+++ b/src/Solr/Query/AbstractQueryBuilder.php
@@ -116,6 +116,12 @@ abstract class AbstractQueryBuilder implements QueryBuilder
     {
         return $this->eventDispatcher;
     }
-    
-    
+
+    /**
+     * @return string
+     */
+    protected function getAttributetoReset()
+    {
+        return $this->attributetoReset;
+    }
 }

--- a/src/Solr/Query/SearchQueryBuilder.php
+++ b/src/Solr/Query/SearchQueryBuilder.php
@@ -114,6 +114,17 @@ final class SearchQueryBuilder extends AbstractQueryBuilder
         return $this->resultsConfig;
     }
 
+    public function build()
+    {
+        return new Query(
+            $this->getStoreId(),
+            $this->getQueryText(),
+            0,
+            $this->getPagination()->getPageSize() * $this->getPagination()->getCurrentPage(),
+            $this->getParamsBuilder()->setBroaden($this->broaden)->buildAsArray($this->getAttributetoReset())
+        );
+    }
+
     /**
      * @return string
      */


### PR DESCRIPTION
This is relevant for search queries containing two words or more where
the words are found in different product attributes. In this case, there
is a mechanism in the search result which searches for the single words
if no results are found otherwise. The mechanism was only used for search
by relevance which is extended to other sort orders with this commit.
Additionally, there was a bug in this mechanism - the parameter "mm=0%"
has to be set for these additional requests.