### PR TITLE
7426 Fix unfuzzy search request if fuzzy is activated

### DIFF
--- a/src/Solr/Query/AbstractParamsBuilder.php
+++ b/src/Solr/Query/AbstractParamsBuilder.php
@@ -99,6 +99,7 @@ abstract class AbstractParamsBuilder implements ParamsBuilder, HasFilter, HasPag
             'facet.mincount' => '1',
             'facet.field' => $this->getFacetFieldCodes(),
             'defType' => 'edismax',
+            'mm' => '1',
         );
 
         $params = $this->addFacetParams($params);

--- a/test/Solr/Query/SearchQueryBuilderTest.php
+++ b/test/Solr/Query/SearchQueryBuilderTest.php
@@ -83,7 +83,8 @@ class SearchQueryBuilderTest extends PHPUnit_Framework_TestCase
             'f.price_f.facet.range.gap' => ResultConfigBuilder::DEFAULT_STEP_SIZE,
             'f.price_f.facet.interval.set' => [
                 "(0.000000,10.000000]", "(10.000000,20.000000]", "(20.000000,30.000000]", "(30.000000,40.000000]", "(40.000000,50.000000]", "(50.000000,*]"
-            ]
+            ],
+            'mm' => '1',
         ];
         $defaultResultConfig = ResultConfigBuilder::defaultConfig()->build();
         $allData = [


### PR DESCRIPTION
If fuzzy search is activated, we are always doing a first,
unfuzzy search request before. This wasn't working correctly
(with newer Solr versions?) and returned 0 results. We are
adding the parameter "mm:1" to such requests as a default
in order to prevent that.