### PR TITLE
Do not require specific minor versions for PHP 5.6 and PHP 7.0 in build

### DIFF
--- a/wercker.yml
+++ b/wercker.yml
@@ -1,6 +1,6 @@
 box: php
 build-56:
-  box: php:5.6.24-cli
+  box: php:5.6-cli
   steps:
     - install-packages:
         packages: git zip
@@ -14,7 +14,7 @@ build-56:
         name: run tests
         code: vendor/bin/phpunit
 build-70:
-  box: php:7.0.9-cli
+  box: php:7.0-cli
   steps:
     - install-packages:
         packages: git zip

--- a/wercker.yml
+++ b/wercker.yml
@@ -3,6 +3,7 @@ build-56:
   box: php:5.6-cli
   steps:
     - install-packages:
+        clear-cache: true
         packages: git zip
     - script:
         name: install composer
@@ -17,6 +18,7 @@ build-70:
   box: php:7.0-cli
   steps:
     - install-packages:
+        clear-cache: true
         packages: git zip
     - script:
         name: install composer


### PR DESCRIPTION
Using a current version should prevent package installation issues