### PR TITLE
7499/indexer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,7 @@
   "description": "Base library for IntegerNet_Solr open source version",
   "type": "magento-module",
   "require": {
+    "php": "^5.6|^7.0|^7.1|^7.2"
   },
   "require-dev": {
     "mikey179/vfsStream": "~1.3",

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   },
   "require-dev": {
     "mikey179/vfsStream": "~1.3",
-    "phpunit/phpunit": "~4.5"
+    "phpunit/phpunit": "^5.0"
   },
   "autoload": {
     "psr-4": {

--- a/src/Solr/Indexer/Data/ProductIdChunk.php
+++ b/src/Solr/Indexer/Data/ProductIdChunk.php
@@ -8,7 +8,7 @@ namespace IntegerNet\Solr\Indexer\Data;
  * @copyright  Copyright (c) 2016 integer_net GmbH (http://www.integer-net.de/)
  * @author     Andreas von Studnitz <avs@integer-net.de>
  */
-final class ProductIdChunk
+final class ProductIdChunk implements \Countable
 {
     /** @var  int[] */
     private $parentIds = array();
@@ -30,11 +30,19 @@ final class ProductIdChunk
     }
 
     /**
-     * @return int
+     * @return int Approximate size based on added products
      */
     public function getSize()
     {
         return $this->size;
+    }
+
+    /**
+     * @return int Real size without duplicates
+     */
+    public function count()
+    {
+        return count($this->getAllIds());
     }
 
     /**

--- a/src/Solr/Indexer/Data/ProductIdChunks.php
+++ b/src/Solr/Indexer/Data/ProductIdChunks.php
@@ -48,4 +48,18 @@ final class ProductIdChunks extends \ArrayIterator
         }
         return $productIdChunks;
     }
+
+    /**
+     * @return int Total number of products in all chunks (with associations)
+     */
+    public function totalCount()
+    {
+        return array_reduce(
+            $this->getArrayCopy(),
+            function ($count, ProductIdChunk $chunk) {
+                return $count + count($chunk);
+            },
+            0
+        );
+    }
 }

--- a/src/Solr/Indexer/Indexer.php
+++ b/src/Solr/Indexer/Indexer.php
@@ -10,8 +10,17 @@
 
 namespace IntegerNet\Solr\Indexer;
 
+use IntegerNet\Solr\Indexer\Progress\ProgressHandler;
+
 interface Indexer
 {
+    /**
+     * Adds a callback for progress updates
+     *
+     * @param ProgressHandler $handler
+     */
+    public function addProgressHandler(ProgressHandler $handler);
+
     /**
      * Add/update entities in index
      *

--- a/src/Solr/Indexer/Indexer.php
+++ b/src/Solr/Indexer/Indexer.php
@@ -15,10 +15,13 @@ interface Indexer
     /**
      * Add/update entities in index
      *
+     * The sliceId/totalNumberSlices parameters are deprecated, they cannot be used together with entityIds/emptyIndex.
+     * Use reindexSlice() instead to reindex slices.
+     *
      * @param string[]|null $entityIds IDs to reindex, depends on content type of the concrete indexer. Null for "all"
      * @param bool $emptyIndex If index should be cleared before writing
      * @param int[]|null $restrictToStoreIds Store IDs to reindex. Null for "all"
-     * @param int|null $sliceId Number of slice for partial reindexing. Null for no partial reindexing
+     * @param int|null $sliceId Number of slice for partial reindexing. Null for no partial reindexing.
      * @param int|null $totalNumberSlices Number of slices. The entities are divided into this many slices.
      */
     public function reindex(
@@ -28,6 +31,12 @@ interface Indexer
         $sliceId = null,
         $totalNumberSlices = null
     );
+
+    /**
+     * @param Slice $slice
+     * @return mixed
+     */
+    public function reindexSlice(Slice $slice, $restrictToStoreIds = null);
 
     /**
      * Delete given entities from index

--- a/src/Solr/Indexer/Indexer.php
+++ b/src/Solr/Indexer/Indexer.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * integer_net Magento Module
+ *
+ * @category   IntegerNet
+ * @package    IntegerNet_Solr
+ * @copyright  Copyright (c) 2017 integer_net GmbH (http://www.integer-net.de/)
+ * @author     Fabian Schmengler <fs@integer-net.de>
+ */
+
+namespace IntegerNet\Solr\Indexer;
+
+interface Indexer
+{
+    /**
+     * Add/update entities in index
+     *
+     * @param string[]|null $entityIds IDs to reindex, depends on content type of the concrete indexer. Null for "all"
+     * @param bool $emptyIndex If index should be cleared before writing
+     * @param int[]|null $restrictToStoreIds Store IDs to reindex. Null for "all"
+     * @param int|null $sliceId Number of slice for partial reindexing. Null for no partial reindexing
+     * @param int|null $totalNumberSlices Number of slices. The entities are divided into this many slices.
+     */
+    public function reindex(
+        $entityIds = null,
+        $emptyIndex = false,
+        $restrictToStoreIds = null,
+        $sliceId = null,
+        $totalNumberSlices = null
+    );
+
+    /**
+     * Delete given entities from index
+     *
+     * @param string[] $entityIds IDs to delete, depends on content type of the concrete indexer.
+     */
+    public function deleteIndex($entityIds);
+
+    /**
+     * Clear index for content type of concrete indexer and given store ID
+     *
+     * @param int $storeId
+     */
+    public function clearIndex($storeId);
+}

--- a/src/Solr/Indexer/Indexer.php
+++ b/src/Solr/Indexer/Indexer.php
@@ -60,4 +60,29 @@ interface Indexer
      * @param int $storeId
      */
     public function clearIndex($storeId);
+
+    /**
+     * Check if swap configuration is valid to reindex given stores
+     * (e.g. all stores with same swap configuration must be reindexed at once)
+     *
+     * @param $restrictToStoreIds
+     */
+    public function checkSwapCoresConfiguration($restrictToStoreIds);
+
+    /**
+     * Swap current core with shadow core (for all given stores)
+     *
+     * @param null|int[] $restrictToStoreIds
+     */
+    public function swapCores($restrictToStoreIds);
+
+    /**
+     * Use the shadow core for subsequent indexing
+     */
+    public function activateSwapCore();
+
+    /**
+     * Do not use the shadow core for subsequent indexing
+     */
+    public function deactivateSwapCore();
 }

--- a/src/Solr/Indexer/ProductIndexer.php
+++ b/src/Solr/Indexer/ProductIndexer.php
@@ -591,8 +591,7 @@ class ProductIndexer implements Indexer
     }
 
     /**
-     * @deprecated Not part of the Indexer interface, public method will be removed in 4.0.0. Use resource directly instead.
-     * @see \IntegerNet\Solr\Resource\ResourceFacade
+     * Use the shadow core for subsequent indexing
      */
     public function activateSwapCore()
     {
@@ -601,8 +600,7 @@ class ProductIndexer implements Indexer
     }
 
     /**
-     * @deprecated Not part of the Indexer interface, public method will be removed in 4.0.0. Use resource directly instead.
-     * @see \IntegerNet\Solr\Resource\ResourceFacade
+     * Do not use the shadow core for subsequent indexing
      */
     public function deactivateSwapCore()
     {
@@ -611,8 +609,8 @@ class ProductIndexer implements Indexer
     }
 
     /**
-     * @deprecated Not part of the Indexer interface, public method will be removed in 4.0.0. Use resource directly instead.
-     * @see \IntegerNet\Solr\Resource\ResourceFacade
+     * Swap current core with shadow core (for all given stores)
+     *
      * @param null|int[] $restrictToStoreIds
      */
     public function swapCores($restrictToStoreIds)
@@ -626,8 +624,9 @@ class ProductIndexer implements Indexer
     }
 
     /**
-     * @deprecated Not part of the Indexer interface, public method will be removed in 4.0.0. Use resource directly instead.
-     * @see \IntegerNet\Solr\Resource\ResourceFacade
+     * Check if swap configuration is valid to reindex given stores
+     * (e.g. all stores with same swap configuration must be reindexed at once)
+     *
      * @param $restrictToStoreIds
      */
     public function checkSwapCoresConfiguration($restrictToStoreIds)

--- a/src/Solr/Indexer/ProductIndexer.php
+++ b/src/Solr/Indexer/ProductIndexer.php
@@ -91,7 +91,10 @@ class ProductIndexer implements Indexer
 
     /**
      * @param array|null $productIds Restrict to given Products if this is set
-     * @param boolean|string $emptyIndex Whether to truncate the index before refilling it
+     * @param boolean|string $emptyIndex Whether to truncate the index before refilling it. Possible values:
+     *                                   true: use config
+     *                                   false: never truncate
+     *                                   'force': always truncate
      * @param null|int[] $restrictToStoreIds
      * @param null|int $sliceId
      * @param null|int $totalNumberSlices
@@ -164,6 +167,12 @@ class ProductIndexer implements Indexer
         if (is_null($productIds) && is_null($sliceId)) {
             $this->swapCores($restrictToStoreIds);
         }
+    }
+
+    public function reindexSlice(Slice $slice, $restrictToStoreIds = null)
+    {
+        //TODO refactor to reduce complexity in reindex()
+        $this->reindex(null, false, $restrictToStoreIds, $slice->id(), $slice->totalNumber());
     }
 
     /**
@@ -539,17 +548,27 @@ class ProductIndexer implements Indexer
         $this->_getResource()->deleteAllDocuments($storeId, self::CONTENT_TYPE);
     }
 
+    /**
+     * @deprecated Not part of the Indexer interface, public method will be removed in 4.0.0. Use resource directly instead.
+     * @see \IntegerNet\Solr\Resource\ResourceFacade
+     */
     public function activateSwapCore()
     {
         $this->_getResource()->setUseSwapIndex();
     }
 
+    /**
+     * @deprecated Not part of the Indexer interface, public method will be removed in 4.0.0. Use resource directly instead.
+     * @see \IntegerNet\Solr\Resource\ResourceFacade
+     */
     public function deactivateSwapCore()
     {
         $this->_getResource()->setUseSwapIndex(false);
     }
 
     /**
+     * @deprecated Not part of the Indexer interface, public method will be removed in 4.0.0. Use resource directly instead.
+     * @see \IntegerNet\Solr\Resource\ResourceFacade
      * @param null|int[] $restrictToStoreIds
      */
     public function swapCores($restrictToStoreIds)
@@ -558,6 +577,8 @@ class ProductIndexer implements Indexer
     }
 
     /**
+     * @deprecated Not part of the Indexer interface, public method will be removed in 4.0.0. Use resource directly instead.
+     * @see \IntegerNet\Solr\Resource\ResourceFacade
      * @param $restrictToStoreIds
      */
     public function checkSwapCoresConfiguration($restrictToStoreIds)

--- a/src/Solr/Indexer/ProductIndexer.php
+++ b/src/Solr/Indexer/ProductIndexer.php
@@ -24,7 +24,7 @@ use IntegerNet\Solr\Implementor\ProductIterator;
 use IntegerNet\Solr\Implementor\ProductRepository;
 use IntegerNet\Solr\Implementor\IndexCategoryRepository;
 
-class ProductIndexer
+class ProductIndexer implements Indexer
 {
     const CONTENT_TYPE = 'product';
 
@@ -98,8 +98,13 @@ class ProductIndexer
      * @throws \Exception
      * @throws \IntegerNet\Solr\Exception
      */
-    public function reindex($productIds = null, $emptyIndex = false, $restrictToStoreIds = null, $sliceId = null, $totalNumberSlices = null)
-    {
+    public function reindex(
+        $productIds = null,
+        $emptyIndex = false,
+        $restrictToStoreIds = null,
+        $sliceId = null,
+        $totalNumberSlices = null
+    ) {
         if (is_null($productIds) && is_null($sliceId)) {
             $this->checkSwapCoresConfiguration($restrictToStoreIds);
         }

--- a/src/Solr/Indexer/Progress/EventFinish.php
+++ b/src/Solr/Indexer/Progress/EventFinish.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace IntegerNet\Solr\Indexer\Progress;
+
+class EventFinish implements ProgressUpdate
+{
+    /**
+     * @var EventStart
+     */
+    private $eventStart;
+    /**
+     * @var int|null
+     */
+    private $timestamp;
+
+    /**
+     * @param EventStart $eventStart
+     * @param int|null $timestamp Timestamp. If null, current time is used.
+     */
+    public function __construct(EventStart $eventStart, $timestamp = null)
+    {
+        $this->eventStart = $eventStart;
+        $this->timestamp = $timestamp ?? microtime(true);
+    }
+
+    public function getEventId()
+    {
+        return $this->eventStart->getEventId();
+    }
+
+    public function getDescription()
+    {
+        return $this->eventStart->getDescription();
+    }
+
+    public function getPercentageCompleted()
+    {
+        return 100;
+    }
+
+    public function getTimestamp()
+    {
+        return $this->timestamp;
+    }
+
+    public function getElapsedTimeMs()
+    {
+        return round(1000*($this->timestamp - $this->eventStart->getTimestamp()));
+    }
+
+}

--- a/src/Solr/Indexer/Progress/EventFinish.php
+++ b/src/Solr/Indexer/Progress/EventFinish.php
@@ -20,7 +20,7 @@ class EventFinish implements ProgressUpdate
     public function __construct(EventStart $eventStart, $timestamp = null)
     {
         $this->eventStart = $eventStart;
-        $this->timestamp = $timestamp ?? microtime(true);
+        $this->timestamp = $timestamp ?: microtime(true);
     }
 
     public function getEventId()

--- a/src/Solr/Indexer/Progress/EventInfo.php
+++ b/src/Solr/Indexer/Progress/EventInfo.php
@@ -27,8 +27,8 @@ class EventInfo implements ProgressUpdate
     public function __construct($description, $eventId = null, $timestamp = null)
     {
         $this->description = $description;
-        $this->eventId = $eventId ?? sha1(uniqid('', true));
-        $this->timestamp = $timestamp ?? microtime(true);
+        $this->eventId = $eventId ?: sha1(uniqid('', true));
+        $this->timestamp = $timestamp ?: microtime(true);
     }
 
     public function getEventId()

--- a/src/Solr/Indexer/Progress/EventInfo.php
+++ b/src/Solr/Indexer/Progress/EventInfo.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace IntegerNet\Solr\Indexer\Progress;
+
+class EventInfo implements ProgressUpdate
+{
+    /**
+     * @var string
+     */
+    private $eventId;
+
+    /**
+     * @var string
+     */
+    private $description;
+    /**
+     * @var int|null
+     */
+    private $timestamp;
+
+
+    /**
+     * @param string $description
+     * @param string|null $eventId Unique event ID. If null, will be generated.
+     * @param int|null $timestamp Timestamp. If null, current time is used.
+     */
+    public function __construct($description, $eventId = null, $timestamp = null)
+    {
+        $this->description = $description;
+        $this->eventId = $eventId ?? sha1(uniqid('', true));
+        $this->timestamp = $timestamp ?? microtime(true);
+    }
+
+    public function getEventId()
+    {
+        return $this->eventId;
+    }
+
+    public function getDescription()
+    {
+        return $this->description;
+    }
+
+    public function getTimestamp()
+    {
+        return $this->timestamp;
+    }
+
+    public function getPercentageCompleted()
+    {
+        return 100;
+    }
+
+    public function getElapsedTimeMs()
+    {
+        return 0;
+    }
+
+}

--- a/src/Solr/Indexer/Progress/EventProgress.php
+++ b/src/Solr/Indexer/Progress/EventProgress.php
@@ -26,7 +26,7 @@ class EventProgress implements ProgressUpdate
     {
         $this->eventStart = $eventStart;
         $this->steps = $steps;
-        $this->timestamp = $timestamp ?? microtime(true);
+        $this->timestamp = $timestamp ?: microtime(true);
     }
 
     public function getEventId()

--- a/src/Solr/Indexer/Progress/EventProgress.php
+++ b/src/Solr/Indexer/Progress/EventProgress.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace IntegerNet\Solr\Indexer\Progress;
+
+class EventProgress implements ProgressUpdate
+{
+    /**
+     * @var EventStart
+     */
+    private $eventStart;
+    /**
+     * @var int|null
+     */
+    private $timestamp;
+    /**
+     * @var int
+     */
+    private $steps;
+
+    /**
+     * @param EventStart $eventStart
+     * @param int $steps
+     * @param int|null $timestamp Timestamp. If null, current time is used.
+     */
+    public function __construct(EventStart $eventStart, $steps, $timestamp = null)
+    {
+        $this->eventStart = $eventStart;
+        $this->steps = $steps;
+        $this->timestamp = $timestamp ?? microtime(true);
+    }
+
+    public function getEventId()
+    {
+        return $this->eventStart->getEventId();
+    }
+
+    public function getDescription()
+    {
+        return $this->eventStart->getDescription();
+    }
+
+    public function getPercentageCompleted()
+    {
+        return $this->eventStart->status()->getPercentageComplete();
+    }
+
+    public function getTimestamp()
+    {
+        return $this->timestamp;
+    }
+
+    public function getElapsedTimeMs()
+    {
+        return round(1000*($this->timestamp - $this->eventStart->getTimestamp()));
+    }
+
+    /**
+     * @return int
+     */
+    public function getSteps()
+    {
+        return $this->steps;
+    }
+}

--- a/src/Solr/Indexer/Progress/EventStart.php
+++ b/src/Solr/Indexer/Progress/EventStart.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace IntegerNet\Solr\Indexer\Progress;
+
+class EventStart implements ProgressUpdate
+{
+    /**
+     * @var string
+     */
+    private $eventId;
+
+    /**
+     * @var string
+     */
+    private $description;
+    /**
+     * @var int|null
+     */
+    private $startTime;
+    /**
+     * @var int
+     */
+    private $expectedSteps;
+
+    /**
+     * @var EventStatus
+     */
+    private $status;
+
+    /**
+     * @param string $description
+     * @param int $expectedSteps
+     * @param string|null $eventId Unique event ID. If null, will be generated.
+     * @param int|null $timestamp Timestamp. If null, current time is used.
+     */
+    public function __construct($description, $expectedSteps = 0, $eventId = null, $timestamp = null)
+    {
+        $this->description = $description;
+        $this->eventId = $eventId ?? sha1(uniqid('', true));
+        $this->startTime = $timestamp ?? microtime(true);
+        $this->expectedSteps = $expectedSteps;
+        $this->status = new EventStatus($this->expectedSteps);
+    }
+
+    public function getEventId()
+    {
+        return $this->eventId;
+    }
+
+    public function getDescription()
+    {
+        return $this->description;
+    }
+
+    public function getTimestamp()
+    {
+        return $this->startTime;
+    }
+
+    public function getPercentageCompleted()
+    {
+        return 0;
+    }
+
+    public function getElapsedTimeMs()
+    {
+        return 0;
+    }
+
+    /**
+     * @return int
+     */
+    public function getExpectedSteps()
+    {
+        return $this->expectedSteps;
+    }
+
+    /**
+     * @return EventStatus
+     */
+    public function status()
+    {
+        return $this->status;
+    }
+}

--- a/src/Solr/Indexer/Progress/EventStart.php
+++ b/src/Solr/Indexer/Progress/EventStart.php
@@ -36,8 +36,8 @@ class EventStart implements ProgressUpdate
     public function __construct($description, $expectedSteps = 0, $eventId = null, $timestamp = null)
     {
         $this->description = $description;
-        $this->eventId = $eventId ?? sha1(uniqid('', true));
-        $this->startTime = $timestamp ?? microtime(true);
+        $this->eventId = $eventId ?: sha1(uniqid('', true));
+        $this->startTime = $timestamp ?: microtime(true);
         $this->expectedSteps = $expectedSteps;
         $this->status = new EventStatus($this->expectedSteps);
     }

--- a/src/Solr/Indexer/Progress/EventStatus.php
+++ b/src/Solr/Indexer/Progress/EventStatus.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace IntegerNet\Solr\Indexer\Progress;
+
+/**
+ * Step counter for single event
+ */
+class EventStatus
+{
+    /**
+     * @var int
+     */
+    private $stepsComplete;
+
+    /**
+     * @var int
+     */
+    private $stepsTotal;
+
+    /**
+     * @param int $stepsTotal
+     */
+    public function __construct($stepsTotal)
+    {
+        $this->stepsTotal = $stepsTotal;
+    }
+
+    public function advance($steps)
+    {
+        $this->stepsComplete += $steps;
+    }
+
+    /**
+     * @return float
+     */
+    public function getPercentageComplete()
+    {
+        return $this->stepsComplete / $this->stepsTotal * 100.0;
+    }
+
+}

--- a/src/Solr/Indexer/Progress/LogFormat.php
+++ b/src/Solr/Indexer/Progress/LogFormat.php
@@ -25,7 +25,7 @@ class LogFormat
         return implode(
             "\t",
             [
-                self::formatDateTimeWithMilliseconds($this->progressUpdate->getTimestamp()),
+                self::formatDateTimeWithMicroseconds($this->progressUpdate->getTimestamp()),
                 $this->progressUpdate->getEventId(),
                 $this->progressUpdate->getDescription(),
                 $this->progressUpdate->getPercentageCompleted() . "%",
@@ -38,8 +38,9 @@ class LogFormat
      * @param int|float $timestamp
      * @return string
      */
-    private static function formatDateTimeWithMilliseconds($timestamp)
+    private static function formatDateTimeWithMicroseconds($timestamp)
     {
-        return \DateTime::createFromFormat('U.u', number_format($timestamp, 6, '.', ''))->format(DATE_RFC3339_EXTENDED);
+        // DATE_RFC3339_EXTENDED but with µs instead of ms for PHP 5.6 compatibility
+        return \DateTime::createFromFormat('U.u', number_format($timestamp, 6, '.', ''))->format('Y-m-d\TH:i:s.uP');
     }
 }

--- a/src/Solr/Indexer/Progress/LogFormat.php
+++ b/src/Solr/Indexer/Progress/LogFormat.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace IntegerNet\Solr\Indexer\Progress;
+
+/**
+ * Single line string representation of progress update (tab separated)
+ */
+class LogFormat
+{
+    /**
+     * @var ProgressUpdate
+     */
+    private $progressUpdate;
+
+    /**
+     * @param ProgressUpdate $progressUpdate
+     */
+    public function __construct(ProgressUpdate $progressUpdate)
+    {
+        $this->progressUpdate = $progressUpdate;
+    }
+
+    public function __toString()
+    {
+        return implode(
+            "\t",
+            [
+                self::formatDateTimeWithMilliseconds($this->progressUpdate->getTimestamp()),
+                $this->progressUpdate->getEventId(),
+                $this->progressUpdate->getDescription(),
+                $this->progressUpdate->getPercentageCompleted() . "%",
+                $this->progressUpdate->getElapsedTimeMs() . "ms",
+            ]
+        );
+    }
+
+    /**
+     * @param int|float $timestamp
+     * @return string
+     */
+    private static function formatDateTimeWithMilliseconds($timestamp)
+    {
+        return \DateTime::createFromFormat('U.u', number_format($timestamp, 6, '.', ''))->format(DATE_RFC3339_EXTENDED);
+    }
+}

--- a/src/Solr/Indexer/Progress/ProgressDispatcher.php
+++ b/src/Solr/Indexer/Progress/ProgressDispatcher.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace IntegerNet\Solr\Indexer\Progress;
+
+/**
+ * Creates progress updates and dispatches them to the configured progress handlers
+ */
+class ProgressDispatcher
+{
+    private $progressHandlers = [];
+
+    /**
+     * @var \SplStack
+     */
+    private $eventsInProgress;
+
+    /**
+     * @param ProgressHandler[] $progressHandlers
+     */
+    public function __construct(array $progressHandlers)
+    {
+        $this->progressHandlers = $progressHandlers;
+        $this->eventsInProgress = new \SplStack();
+    }
+
+    public function info($eventDescription, $eventId = null, $timestamp = null)
+    {
+        $update = new EventInfo($eventDescription, $eventId, $timestamp);
+        $this->dispatchUpdate($update);
+    }
+
+    public function start($eventDescription, $expectedSteps = 0, $eventId = null, $timestamp = null)
+    {
+        $update = new EventStart($eventDescription, $expectedSteps, $eventId, $timestamp);
+        $this->eventsInProgress->push($update);
+        $this->dispatchUpdate($update);
+    }
+
+    public function advance($steps = 1, $timestamp = null)
+    {
+        /** @var EventStart $currentEvent */
+        $currentEvent = $this->eventsInProgress->top();
+        $currentEvent->status()->advance($steps);
+        $this->dispatchUpdate(
+            new EventProgress($currentEvent, $steps, $timestamp)
+        );
+    }
+
+    public function finish($timestamp = null)
+    {
+        $this->dispatchUpdate(
+            new EventFinish(
+                $this->eventsInProgress->pop(),
+                $timestamp
+            )
+        );
+    }
+
+    private function dispatchUpdate($update)
+    {
+        foreach ($this->progressHandlers as $handler) {
+            $handler->progress($update);
+        }
+    }
+}

--- a/src/Solr/Indexer/Progress/ProgressHandler.php
+++ b/src/Solr/Indexer/Progress/ProgressHandler.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace IntegerNet\Solr\Indexer\Progress;
+
+/**
+ * Progress handler to be implemented by client, e.g. CLI output
+ */
+interface ProgressHandler
+{
+    public function progress(ProgressUpdate $update);
+}

--- a/src/Solr/Indexer/Progress/ProgressUpdate.php
+++ b/src/Solr/Indexer/Progress/ProgressUpdate.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace IntegerNet\Solr\Indexer\Progress;
+
+/**
+ * Interface for progress update events, emitted by the indexer. Can be handled by clients via status update callbacks.
+ */
+interface ProgressUpdate
+{
+    /**
+     * @return string Unique identifier for given event, used to associate multiple updates (start, progress, finished)
+     *                for the same event
+     */
+    public function getEventId();
+
+    /**
+     * @return string Description of the event, e.g. "Clearing index for store de_DE"
+     */
+    public function getDescription();
+
+    /**
+     * @return float Completion of the event, i.e. "0" for started event, "100" for completed event, anything in between
+     * for progress updates
+     */
+    public function getPercentageCompleted();
+
+    /**
+     * @return float Unix timestamp of status update (with microseconds)
+     */
+    public function getTimestamp();
+
+    /**
+     * @return int Elapsed time of the event in milliseconds
+     */
+    public function getElapsedTimeMs();
+}

--- a/src/Solr/Indexer/Slice.php
+++ b/src/Solr/Indexer/Slice.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace IntegerNet\Solr\Indexer;
+
+class Slice
+{
+    /**
+     * @var int
+     */
+    private $sliceId;
+    /**
+     * @var int
+     */
+    private $totalNumberSlices;
+
+    /**
+     * @param int $sliceId
+     * @param int $totalNumberSlices
+     * @throws \InvalidArgumentException
+     */
+    public function __construct($sliceId, $totalNumberSlices)
+    {
+        if ((int) $sliceId < 1) {
+            throw new \InvalidArgumentException('Invalid slice number. Slice numbers start at 1.');
+        }
+        if ((int)$sliceId > (int)$totalNumberSlices) {
+            throw new \InvalidArgumentException(
+                'Invalid slice number. Slice number must be less than or equal total number of slices.'
+            );
+        }
+        $this->sliceId = (int) $sliceId;
+        $this->totalNumberSlices = (int) $totalNumberSlices;
+    }
+
+    /**
+     * @param string $expression
+     * @return Slice
+     * @throws \InvalidArgumentException
+     */
+    public static function fromExpression($expression)
+    {
+        $parts = explode('/', $expression);
+        if (count($parts) !== 2 || !ctype_digit(implode('', $parts))) {
+            throw new \InvalidArgumentException(
+                "Invalid slice expression. Expression must contain two numbers separated by '/', e.g. '1/5'"
+            );
+        }
+        return new self(...$parts);
+    }
+
+    /**
+     * @return int
+     */
+    public function id()
+    {
+        return $this->sliceId;
+    }
+
+    /**
+     * @return int
+     */
+    public function totalNumber()
+    {
+        return $this->totalNumberSlices;
+    }
+}

--- a/test/Solr/Indexer/Progress/FakeProgressHandler.php
+++ b/test/Solr/Indexer/Progress/FakeProgressHandler.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace IntegerNet\Solr\Indexer\Progress;
+
+/**
+ * Fake progress handler for tests, just collects the updates for inspection
+ */
+class FakeProgressHandler implements ProgressHandler
+{
+    public $updates = [];
+    public $updatesAsString = [];
+
+    public function progress(ProgressUpdate $update)
+    {
+        $this->updates[] = $update;
+        $this->updatesAsString[] = (string) new LogFormat($update);
+    }
+}

--- a/test/Solr/Indexer/Progress/ProgressUpdateTest.php
+++ b/test/Solr/Indexer/Progress/ProgressUpdateTest.php
@@ -1,0 +1,50 @@
+<?php
+namespace IntegerNet\Solr\Indexer\Progress;
+
+class ProgressUpdateTest extends \PHPUnit\Framework\TestCase
+{
+    public function testStartAndFinishEvent()
+    {
+        $eventId = 'xxxxxx';
+        $startTime = strtotime('2001-02-03 04:05:06');
+        $endTime = $startTime + 0.05;
+        $eventDescription = 'Running test';
+
+        $handler = new FakeProgressHandler();
+        $progress = new ProgressDispatcher([$handler]);
+        $progress->start($eventDescription, 0, $eventId, $startTime);
+        $progress->finish($endTime);
+
+        $this->assertEquals(
+            [
+                "2001-02-03T04:05:06.000+00:00\t$eventId\t$eventDescription\t0%\t0ms",
+                "2001-02-03T04:05:06.050+00:00\t$eventId\t$eventDescription\t100%\t50ms",
+            ],
+            $handler->updatesAsString
+        );
+    }
+    public function testEventWithProgress()
+    {
+        $eventId = 'xxxxxx';
+        $startTime = strtotime('2001-02-03 04:05:06');
+        $endTime = $startTime + 0.01;
+        $eventDescription = 'Running test';
+
+        $handler = new FakeProgressHandler();
+        $progress = new ProgressDispatcher([$handler]);
+        $progress->start($eventDescription, 2, $eventId, $startTime);
+        $progress->advance(1, $startTime);
+        $progress->advance(1, $endTime);
+        $progress->finish($endTime);
+
+        $this->assertEquals(
+            [
+                "2001-02-03T04:05:06.000+00:00\t$eventId\t$eventDescription\t0%\t0ms",
+                "2001-02-03T04:05:06.000+00:00\t$eventId\t$eventDescription\t50%\t0ms",
+                "2001-02-03T04:05:06.010+00:00\t$eventId\t$eventDescription\t100%\t10ms",
+                "2001-02-03T04:05:06.010+00:00\t$eventId\t$eventDescription\t100%\t10ms",
+            ],
+            $handler->updatesAsString
+        );
+    }
+}

--- a/test/Solr/Indexer/Progress/ProgressUpdateTest.php
+++ b/test/Solr/Indexer/Progress/ProgressUpdateTest.php
@@ -17,8 +17,8 @@ class ProgressUpdateTest extends \PHPUnit\Framework\TestCase
 
         $this->assertEquals(
             [
-                "2001-02-03T04:05:06.000+00:00\t$eventId\t$eventDescription\t0%\t0ms",
-                "2001-02-03T04:05:06.050+00:00\t$eventId\t$eventDescription\t100%\t50ms",
+                "2001-02-03T04:05:06.000000+00:00\t$eventId\t$eventDescription\t0%\t0ms",
+                "2001-02-03T04:05:06.050000+00:00\t$eventId\t$eventDescription\t100%\t50ms",
             ],
             $handler->updatesAsString
         );
@@ -39,10 +39,10 @@ class ProgressUpdateTest extends \PHPUnit\Framework\TestCase
 
         $this->assertEquals(
             [
-                "2001-02-03T04:05:06.000+00:00\t$eventId\t$eventDescription\t0%\t0ms",
-                "2001-02-03T04:05:06.000+00:00\t$eventId\t$eventDescription\t50%\t0ms",
-                "2001-02-03T04:05:06.010+00:00\t$eventId\t$eventDescription\t100%\t10ms",
-                "2001-02-03T04:05:06.010+00:00\t$eventId\t$eventDescription\t100%\t10ms",
+                "2001-02-03T04:05:06.000000+00:00\t$eventId\t$eventDescription\t0%\t0ms",
+                "2001-02-03T04:05:06.000000+00:00\t$eventId\t$eventDescription\t50%\t0ms",
+                "2001-02-03T04:05:06.010000+00:00\t$eventId\t$eventDescription\t100%\t10ms",
+                "2001-02-03T04:05:06.010000+00:00\t$eventId\t$eventDescription\t100%\t10ms",
             ],
             $handler->updatesAsString
         );

--- a/test/Solr/Indexer/SliceTest.php
+++ b/test/Solr/Indexer/SliceTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace IntegerNet\Solr\Indexer;
+
+use PHPUnit\Framework\TestCase;
+
+class SliceTest extends TestCase
+{
+    /**
+     * @dataProvider dataValidExpression
+     */
+    public function testCanBeInstantiatedFromValidExpression($expression, $expectedNumber, $expectedTotalNumber)
+    {
+        $slice = Slice::fromExpression($expression);
+        $this->assertEquals(new Slice($expectedNumber, $expectedTotalNumber), $slice);
+    }
+
+    public static function dataValidExpression()
+    {
+        return [
+            '1/5' => ['1/5', 1, 5],
+            '5/5' => ['5/5', 5, 5],
+            '1/1' => ['1/1', 1, 1],
+        ];
+    }
+    /**
+     * @dataProvider dataInvalidExpression
+     */
+    public function testCannotBeInstantiatedFromInvalidExpression($expression)
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        Slice::fromExpression($expression);
+    }
+
+    public static function dataInvalidExpression()
+    {
+        return [
+            '0/5' => ['0/5'],
+            '6/5' => ['6/5'],
+            '' => [''],
+            '1/' => ['1/'],
+            '/2' => ['/2'],
+            '1' => ['1'],
+            'foo/bar' => ['foo/bar'],
+            '1/2/3' => ['1/2/3'],
+            '1.5/5' => ['1.5/5'],
+            '1/2.5' => ['1/2.5'],
+        ];
+    }
+}

--- a/test/Solr/Resource/ServiceChainTest.php
+++ b/test/Solr/Resource/ServiceChainTest.php
@@ -19,9 +19,9 @@ class ServiceChainTest extends PHPUnit_Framework_TestCase
     {
         /** @var \PHPUnit_Framework_MockObject_MockObject[] $mockServices */
         $mockServices = [
-            $this->getMock(ServiceBase::class, ['newMethod1']),
-            $this->getMock(ServiceBase::class, ['newMethod1', 'newMethod2']),
-            $this->getMock(ServiceBase::class, ['newMethod3']),
+            $this->getMockBuilder(ServiceBase::class)->setMethods(['newMethod1'])->getMock(),
+            $this->getMockBuilder(ServiceBase::class)->setMethods(['newMethod1', 'newMethod2'])->getMock(),
+            $this->getMockBuilder(ServiceBase::class)->setMethods(['newMethod3'])->getMock(),
         ];
         $mockServices[0]->expects($this->once())->method('newMethod1')->with('parameter1')->willReturn('return1');
         $mockServices[1]->expects($this->once())->method('newMethod2')->with('parameter2')->willReturn('return2');
@@ -42,7 +42,7 @@ class ServiceChainTest extends PHPUnit_Framework_TestCase
     public function shouldThrowExceptionIfMethodNotFoundInChain()
     {
         $base = new ServiceBase();
-        $base->appendService($this->getMock(ServiceBase::class, ['newMethod']));
+        $base->appendService($this->getMockBuilder(ServiceBase::class)->setMethods(['newMethod'])->getMock());
         $base->nonexistendMethod();
     }
 }


### PR DESCRIPTION
This PR contains

- new indexer method `reindexSlice()` as nicer interface to reindex slices. The old way with additional parameters to `reindex()` still works, but has been deprecated
- an interface for the indexer. This is supposed to be used by other indexers (category indexer, cms indexer) as well to make it easier to use various indexers from a single place, like a CLI command. Public methods of the indexer that were only used by itself are not part of the interface and marked as deprecated in the class.
- a progress update dispatcher for the indexer. Clients can register progress handlers who receive updates about the indexer progress, which can be used to log or display the status during indexing
- PHPUnit requirement changed from 4 to 5 (4 to 6 requires too much change at once, 5 to 6 comes next)