### PR TITLE
Boost full word matches

### DIFF
--- a/conf/mapping-ISOLatin1Accent.txt
+++ b/conf/mapping-ISOLatin1Accent.txt
@@ -1,0 +1,246 @@
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Syntax:
+#   "source" => "target"
+#     "source".length() > 0 (source cannot be empty.)
+#     "target".length() >= 0 (target can be empty.)
+
+# example:
+#   "À" => "A"
+#   "\u00C0" => "A"
+#   "\u00C0" => "\u0041"
+#   "ß" => "ss"
+#   "\t" => " "
+#   "\n" => ""
+
+# À => A
+"\u00C0" => "A"
+
+# Á => A
+"\u00C1" => "A"
+
+# Â => A
+"\u00C2" => "A"
+
+# Ã => A
+"\u00C3" => "A"
+
+# Ä => A
+"\u00C4" => "A"
+
+# Å => A
+"\u00C5" => "A"
+
+# Æ => AE
+"\u00C6" => "AE"
+
+# Ç => C
+"\u00C7" => "C"
+
+# È => E
+"\u00C8" => "E"
+
+# É => E
+"\u00C9" => "E"
+
+# Ê => E
+"\u00CA" => "E"
+
+# Ë => E
+"\u00CB" => "E"
+
+# Ì => I
+"\u00CC" => "I"
+
+# Í => I
+"\u00CD" => "I"
+
+# Î => I
+"\u00CE" => "I"
+
+# Ï => I
+"\u00CF" => "I"
+
+# Ĳ => IJ
+"\u0132" => "IJ"
+
+# Ð => D
+"\u00D0" => "D"
+
+# Ñ => N
+"\u00D1" => "N"
+
+# Ò => O
+"\u00D2" => "O"
+
+# Ó => O
+"\u00D3" => "O"
+
+# Ô => O
+"\u00D4" => "O"
+
+# Õ => O
+"\u00D5" => "O"
+
+# Ö => O
+"\u00D6" => "O"
+
+# Ø => O
+"\u00D8" => "O"
+
+# Œ => OE
+"\u0152" => "OE"
+
+# Þ
+"\u00DE" => "TH"
+
+# Ù => U
+"\u00D9" => "U"
+
+# Ú => U
+"\u00DA" => "U"
+
+# Û => U
+"\u00DB" => "U"
+
+# Ü => U
+"\u00DC" => "U"
+
+# Ý => Y
+"\u00DD" => "Y"
+
+# Ÿ => Y
+"\u0178" => "Y"
+
+# à => a
+"\u00E0" => "a"
+
+# á => a
+"\u00E1" => "a"
+
+# â => a
+"\u00E2" => "a"
+
+# ã => a
+"\u00E3" => "a"
+
+# ä => a
+"\u00E4" => "a"
+
+# å => a
+"\u00E5" => "a"
+
+# æ => ae
+"\u00E6" => "ae"
+
+# ç => c
+"\u00E7" => "c"
+
+# è => e
+"\u00E8" => "e"
+
+# é => e
+"\u00E9" => "e"
+
+# ê => e
+"\u00EA" => "e"
+
+# ë => e
+"\u00EB" => "e"
+
+# ì => i
+"\u00EC" => "i"
+
+# í => i
+"\u00ED" => "i"
+
+# î => i
+"\u00EE" => "i"
+
+# ï => i
+"\u00EF" => "i"
+
+# ĳ => ij
+"\u0133" => "ij"
+
+# ð => d
+"\u00F0" => "d"
+
+# ñ => n
+"\u00F1" => "n"
+
+# ò => o
+"\u00F2" => "o"
+
+# ó => o
+"\u00F3" => "o"
+
+# ô => o
+"\u00F4" => "o"
+
+# õ => o
+"\u00F5" => "o"
+
+# ö => o
+"\u00F6" => "o"
+
+# ø => o
+"\u00F8" => "o"
+
+# œ => oe
+"\u0153" => "oe"
+
+# ß => ss
+"\u00DF" => "ss"
+
+# þ => th
+"\u00FE" => "th"
+
+# ù => u
+"\u00F9" => "u"
+
+# ú => u
+"\u00FA" => "u"
+
+# û => u
+"\u00FB" => "u"
+
+# ü => u
+"\u00FC" => "u"
+
+# ý => y
+"\u00FD" => "y"
+
+# ÿ => y
+"\u00FF" => "y"
+
+# ﬀ => ff
+"\uFB00" => "ff"
+
+# ﬁ => fi
+"\uFB01" => "fi"
+
+# ﬂ => fl
+"\uFB02" => "fl"
+
+# ﬃ => ffi
+"\uFB03" => "ffi"
+
+# ﬄ => ffl
+"\uFB04" => "ffl"
+
+# ﬅ => ft
+"\uFB05" => "ft"
+
+# ﬆ => st
+"\uFB06" => "st"

--- a/conf/protwords.txt
+++ b/conf/protwords.txt
@@ -1,0 +1,21 @@
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#-----------------------------------------------------------------------
+# Use a protected word file to protect against the stemmer reducing two
+# unrelated words to the same base word.
+
+# Some non-words that normally won't be encountered,
+# just to test that they won't be stemmed.
+dontstems
+zwhacky
+

--- a/conf/schema.xml
+++ b/conf/schema.xml
@@ -1,0 +1,201 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<schema name="integernet-solr" version="1.5">
+
+    <types>
+        <fieldType name="string" class="solr.StrField" sortMissingLast="true" omitNorms="false"/>
+        <fieldType name="boolean" class="solr.BoolField" sortMissingLast="true" omitNorms="false"/>
+        <fieldtype name="binary" class="solr.BinaryField"/>
+        <fieldType name="int" class="solr.TrieIntField" precisionStep="0" omitNorms="false" positionIncrementGap="0"/>
+        <fieldType name="float" class="solr.TrieFloatField" precisionStep="0" omitNorms="false" positionIncrementGap="0"/>
+        <fieldType name="long" class="solr.TrieLongField" precisionStep="0" omitNorms="false" positionIncrementGap="0"/>
+        <fieldType name="double" class="solr.TrieDoubleField" precisionStep="0" omitNorms="false" positionIncrementGap="0"/>
+        <fieldType name="tint" class="solr.TrieIntField" precisionStep="8" omitNorms="false" positionIncrementGap="0"/>
+        <fieldType name="tfloat" class="solr.TrieFloatField" precisionStep="8" omitNorms="false" positionIncrementGap="0"/>
+        <fieldType name="tlong" class="solr.TrieLongField" precisionStep="8" omitNorms="false" positionIncrementGap="0"/>
+        <fieldType name="tdouble" class="solr.TrieDoubleField" precisionStep="8" omitNorms="false" positionIncrementGap="0"/>
+        <fieldType name="date" class="solr.TrieDateField" omitNorms="false" precisionStep="0" positionIncrementGap="0"/>
+        <fieldType name="tdate" class="solr.TrieDateField" omitNorms="false" precisionStep="6" positionIncrementGap="0"/>
+
+        <fieldType name="text_ws" class="solr.TextField" positionIncrementGap="100">
+            <analyzer>
+                <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+            </analyzer>
+        </fieldType>
+
+        <fieldType name="text" class="solr.TextField" positionIncrementGap="100">
+            <analyzer type="index">
+                <charFilter class="solr.MappingCharFilterFactory" mapping="mapping-ISOLatin1Accent.txt"/>
+                <tokenizer class="solr.StandardTokenizerFactory"/>
+                <filter class="solr.SynonymFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
+      			<filter class="solr.ShingleFilterFactory" minShingleSize="2" maxShingleSize="3"
+         			outputUnigrams="true" outputUnigramsIfNoShingles="false" tokenSeparator=""/>
+                <filter class="solr.NGramFilterFactory" maxGramSize="15" minGramSize="2"/>
+                <filter class="solr.WordDelimiterFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1" catenateNumbers="1" catenateAll="1" splitOnCaseChange="1" splitOnNumerics="0" />
+                <filter class="solr.LowerCaseFilterFactory"/>
+            </analyzer>
+            <analyzer type="query">
+                <charFilter class="solr.MappingCharFilterFactory" mapping="mapping-ISOLatin1Accent.txt"/>
+                <tokenizer class="solr.StandardTokenizerFactory"/>
+      			<filter class="solr.ShingleFilterFactory" minShingleSize="2" maxShingleSize="3"
+         			outputUnigrams="true" outputUnigramsIfNoShingles="false" tokenSeparator=""/>
+                <filter class="solr.WordDelimiterFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1" catenateNumbers="1" catenateAll="1" splitOnCaseChange="1" splitOnNumerics="0" />
+                <filter class="solr.LowerCaseFilterFactory"/>
+            </analyzer>
+        </fieldType>
+
+        <!--
+            Fields of this type will not be stemmed, that means that only the whole word will be indexed and not parts of it.
+            This is to make sure that full word matches are weighed higher then partly matches.
+        -->
+        <fieldType name="textnostem" class="solr.TextField" positionIncrementGap="100">
+            <analyzer type="index">
+                <charFilter class="solr.MappingCharFilterFactory" mapping="mapping-ISOLatin1Accent.txt"/>
+                <tokenizer class="solr.StandardTokenizerFactory"/>
+                <filter class="solr.SynonymFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
+      			<filter class="solr.ShingleFilterFactory" minShingleSize="2" maxShingleSize="3"
+         			outputUnigrams="true" outputUnigramsIfNoShingles="false" tokenSeparator=""/>
+                <filter class="solr.WordDelimiterFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1" catenateNumbers="1" catenateAll="1" splitOnCaseChange="1" splitOnNumerics="0" />
+                <filter class="solr.LowerCaseFilterFactory"/>
+            </analyzer>
+            <analyzer type="query">
+                <charFilter class="solr.MappingCharFilterFactory" mapping="mapping-ISOLatin1Accent.txt"/>
+                <tokenizer class="solr.StandardTokenizerFactory"/>
+      			<filter class="solr.ShingleFilterFactory" minShingleSize="2" maxShingleSize="3"
+         			outputUnigrams="true" outputUnigramsIfNoShingles="false" tokenSeparator=""/>
+                <filter class="solr.WordDelimiterFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1" catenateNumbers="1" catenateAll="1" splitOnCaseChange="1" splitOnNumerics="0" />
+                <filter class="solr.LowerCaseFilterFactory"/>
+            </analyzer>
+        </fieldType>
+
+        <fieldType name="textgen" class="solr.TextField" positionIncrementGap="100">
+            <analyzer type="index">
+                <charFilter class="solr.MappingCharFilterFactory" mapping="mapping-ISOLatin1Accent.txt"/>
+                <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+                <filter class="solr.NGramFilterFactory" maxGramSize="25" minGramSize="2"/>
+                <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" />
+                <filter class="solr.WordDelimiterFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1" catenateNumbers="1" catenateAll="1" splitOnCaseChange="1" splitOnNumerics="0" />
+                <filter class="solr.LowerCaseFilterFactory"/>
+            </analyzer>
+            <analyzer type="query">
+                <charFilter class="solr.MappingCharFilterFactory" mapping="mapping-ISOLatin1Accent.txt"/>
+                <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+                <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" />
+                <filter class="solr.WordDelimiterFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1" catenateNumbers="1" catenateAll="1" splitOnCaseChange="1" splitOnNumerics="0" />
+                <filter class="solr.LowerCaseFilterFactory"/>
+            </analyzer>
+        </fieldType>
+
+        <fieldType name="text_rev" class="solr.TextField" positionIncrementGap="100">
+            <analyzer type="index">
+                <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+                <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" />
+                <filter class="solr.WordDelimiterFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1" catenateNumbers="1" catenateAll="0" splitOnCaseChange="0"/>
+                <filter class="solr.LowerCaseFilterFactory"/>
+                <filter class="solr.ReversedWildcardFilterFactory" withOriginal="true"
+                        maxPosAsterisk="3" maxPosQuestion="2" maxFractionAsterisk="0.33"/>
+            </analyzer>
+            <analyzer type="query">
+                <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+                <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" />
+                <filter class="solr.WordDelimiterFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="0" catenateNumbers="0" catenateAll="0" splitOnCaseChange="0"/>
+                <filter class="solr.LowerCaseFilterFactory"/>
+            </analyzer>
+        </fieldType>
+
+        <fieldType name="text_autocomplete" class="solr.TextField" positionIncrementGap="100">
+            <analyzer>
+                <charFilter class="solr.MappingCharFilterFactory" mapping="mapping-ISOLatin1Accent.txt"/>
+                <tokenizer class="solr.StandardTokenizerFactory"/>
+                <filter class="solr.LowerCaseFilterFactory"/>
+                <filter class="solr.ShingleFilterFactory" maxShingleSize="3" outputUnigrams="true"/>
+            </analyzer>
+        </fieldType>
+
+        <fieldtype name="payloads" stored="false" indexed="true" class="solr.TextField" >
+            <analyzer>
+                <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+                <filter class="solr.DelimitedPayloadTokenFilterFactory" encoder="float"/>
+            </analyzer>
+        </fieldtype>
+
+        <fieldType name="lowercase" class="solr.TextField" positionIncrementGap="100">
+            <analyzer>
+                <tokenizer class="solr.KeywordTokenizerFactory"/>
+                <filter class="solr.LowerCaseFilterFactory" />
+            </analyzer>
+        </fieldType>
+
+        <fieldtype name="ignored" stored="false" indexed="false" multiValued="true" class="solr.StrField" />
+    </types>
+
+
+    <fields>
+        <field name="_version_" type="long" indexed="true" stored="true"/>
+        <field name="id" type="string" indexed="true" stored="true" required="true" />
+        <field name="category" type="int" indexed="true" stored="true" multiValued="true" omitNorms="true" />
+        <field name="store_id" type="int" indexed="true" stored="true" required="true" />
+        <field name="product_id" type="int" indexed="true" stored="true" required="true"/>
+        <field name="content_type" type="string" indexed="true" stored="true" required="true"/>
+
+        <!-- catchall field, containing all other searchable text fields (implemented
+             via copyField further on in this schema  -->
+        <field name="text" type="text" indexed="true" stored="false" multiValued="true"/>
+        <field name="text_plain" type="textgen" indexed="true" stored="false" multiValued="true"/>
+        <field name="text_autocomplete" type="text_autocomplete" indexed="true" stored="false" multiValued="true"/>
+
+        <!-- catchall text field that indexes tokens both normally and in reverse for efficient
+             leading wildcard queries. -->
+        <field name="text_rev" type="text_rev" indexed="true" stored="false" multiValued="true"/>
+
+        <field name="payloads" type="payloads" indexed="true" stored="true"/>
+
+        <field name="price_f" type="float" indexed="true" stored="true" docValues="true" default="0" />
+
+        <!-- "int" was too short for the generated category positions. -->
+        <dynamicField name="*_position_i"  type="tlong"    indexed="true"  stored="true" />
+        <dynamicField name="*_i"  type="int"    indexed="true"  stored="true" />
+        <dynamicField name="*_s"  type="string"  indexed="true"  stored="true" />
+        <dynamicField name="*_l"  type="long"   indexed="true"  stored="true" />
+        <dynamicField name="*_t"  type="text"    indexed="true"  stored="true" />
+        <dynamicField name="*_t_ns"  type="textnostem"    indexed="true"  stored="true" />
+        <dynamicField name="*_b"  type="boolean" indexed="true"  stored="true" />
+        <dynamicField name="*_f"  type="float"  indexed="true"  stored="true" />
+        <dynamicField name="*_d"  type="double" indexed="true"  stored="true" />
+        <dynamicField name="*_dt" type="date"    indexed="true"  stored="true" />
+        <dynamicField name="*_i_mv"  type="int"    indexed="true"  stored="true" multiValued="true" />
+        <dynamicField name="*_s_mv"  type="string"  indexed="true"  stored="true" multiValued="true" />
+        <dynamicField name="*_l_mv"  type="long"   indexed="true"  stored="true" multiValued="true" />
+        <dynamicField name="*_t_mv"  type="text"    indexed="true"  stored="true" multiValued="true" />
+        <dynamicField name="*_t_ns_mv"  type="textnostem"    indexed="true"  stored="true" multiValued="true" />
+        <dynamicField name="*_b_mv"  type="boolean" indexed="true"  stored="true" multiValued="true" />
+        <dynamicField name="*_f_mv"  type="float"  indexed="true"  stored="true" multiValued="true" />
+        <dynamicField name="*_d_mv"  type="double" indexed="true"  stored="true" multiValued="true" />
+        <dynamicField name="*_dt_mv" type="date"    indexed="true"  stored="true" multiValued="true" />
+        <dynamicField name="*_nonindex" type="text"    indexed="false"  stored="true"/>
+
+        <dynamicField name="ignored_*" type="ignored" multiValued="true"/>
+        <dynamicField name="attr_*" type="textgen" indexed="true" stored="true" multiValued="true"/>
+        <dynamicField name="*_facet" type="int" indexed="true" stored="true" multiValued="true" docValues="true" />
+    </fields>
+
+    <uniqueKey>id</uniqueKey>
+
+    <defaultSearchField>text</defaultSearchField>
+
+    <solrQueryParser defaultOperator="AND"/>
+
+    <copyField source="*_t" dest="text"/>
+    <copyField source="*_s" dest="text"/>
+    <copyField source="*_t_mv" dest="text"/>
+    <copyField source="*_s_mv" dest="text"/>
+
+    <copyField source="*_t" dest="text_plain"/>
+    <copyField source="*_s" dest="text_plain"/>
+    <copyField source="*_t_mv" dest="text_plain"/>
+    <copyField source="*_s_mv" dest="text_plain"/>
+
+    <copyField source="*_t_ns" dest="text_autocomplete"/>
+    <copyField source="*_s" dest="text_autocomplete"/>
+    <copyField source="*_t_ns_mv" dest="text_autocomplete"/>
+    <copyField source="*_s_mv" dest="text_autocomplete"/>
+</schema>

--- a/conf/solrconfig.xml
+++ b/conf/solrconfig.xml
@@ -1,0 +1,254 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<!--
+     For more details about configurations options that may appear in
+     this file, see http://wiki.apache.org/solr/SolrConfigXml.
+-->
+<config>
+    <luceneMatchVersion>LUCENE_42</luceneMatchVersion>
+<!--
+    <lib dir="${solr.install.dir:../../../..}/dist/" regex="solr-dataimporthandler-.*\.jar" />
+
+    <lib dir="${solr.install.dir:../../../..}/contrib/extraction/lib" regex=".*\.jar" />
+    <lib dir="${solr.install.dir:../../../..}/dist/" regex="solr-cell-\d.*\.jar" />
+
+    <lib dir="${solr.install.dir:../../../..}/contrib/clustering/lib/" regex=".*\.jar" />
+    <lib dir="${solr.install.dir:../../../..}/dist/" regex="solr-clustering-\d.*\.jar" />
+
+    <lib dir="${solr.install.dir:../../../..}/contrib/langid/lib/" regex=".*\.jar" />
+    <lib dir="${solr.install.dir:../../../..}/dist/" regex="solr-langid-\d.*\.jar" />
+
+    <lib dir="${solr.install.dir:../../../..}/contrib/velocity/lib" regex=".*\.jar" />
+    <lib dir="${solr.install.dir:../../../..}/dist/" regex="solr-velocity-\d.*\.jar" />
+-->
+    <dataDir>${solr.data.dir:}</dataDir>
+
+    <directoryFactory name="DirectoryFactory"
+                      class="${solr.directoryFactory:solr.NRTCachingDirectoryFactory}"/>
+
+    <codecFactory class="solr.SchemaCodecFactory"/>
+
+    <indexConfig>
+        <lockType>${solr.lock.type:native}</lockType>
+    </indexConfig>
+
+    <jmx />
+
+    <updateHandler class="solr.DirectUpdateHandler2">
+        <updateLog>
+            <str name="dir">${solr.ulog.dir:}</str>
+        </updateLog>
+
+        <autoCommit>
+            <maxTime>15000</maxTime>
+            <openSearcher>false</openSearcher>
+        </autoCommit>
+    </updateHandler>
+
+    <query>
+        <maxBooleanClauses>1024</maxBooleanClauses>
+
+        <filterCache class="solr.FastLRUCache"
+                     size="512"
+                     initialSize="512"
+                     autowarmCount="0"/>
+
+        <queryResultCache class="solr.LRUCache"
+                          size="512"
+                          initialSize="512"
+                          autowarmCount="0"/>
+
+        <documentCache class="solr.LRUCache"
+                       size="512"
+                       initialSize="512"
+                       autowarmCount="0"/>
+
+        <enableLazyFieldLoading>true</enableLazyFieldLoading>
+
+        <queryResultWindowSize>20</queryResultWindowSize>
+
+        <queryResultMaxDocsCached>200</queryResultMaxDocsCached>
+
+        <listener event="newSearcher" class="solr.QuerySenderListener">
+            <arr name="queries" />
+        </listener>
+
+        <listener event="firstSearcher" class="solr.QuerySenderListener">
+            <arr name="queries">
+                <lst>
+                    <str name="q">static firstSearcher warming in solrconfig.xml</str>
+                </lst>
+            </arr>
+        </listener>
+
+        <useColdSearcher>false</useColdSearcher>
+
+        <maxWarmingSearchers>2</maxWarmingSearchers>
+    </query>
+
+    <requestDispatcher handleSelect="false">
+        <requestParsers enableRemoteStreaming="true"
+                        multipartUploadLimitInKB="2048000"
+                        formdataUploadLimitInKB="2048"
+                        addHttpRequestToContext="false" />
+
+        <httpCaching never304="true" />
+    </requestDispatcher>
+
+    <requestHandler name="/select" class="solr.SearchHandler">
+        <lst name="defaults">
+            <str name="echoParams">explicit</str>
+            <int name="rows">10</int>
+            <str name="df">text</str>
+        </lst>
+    </requestHandler>
+
+    <requestHandler name="/query" class="solr.SearchHandler">
+        <lst name="defaults">
+            <str name="echoParams">explicit</str>
+            <str name="wt">json</str>
+            <str name="indent">true</str>
+            <str name="df">text</str>
+        </lst>
+    </requestHandler>
+
+    <requestHandler name="/get" class="solr.RealTimeGetHandler">
+        <lst name="defaults">
+            <str name="omitHeader">true</str>
+            <str name="wt">json</str>
+            <str name="indent">true</str>
+        </lst>
+    </requestHandler>
+
+    <initParams path="/update/**,/query,/select,/tvrh,/elevate,/spell,/browse">
+        <lst name="defaults">
+            <str name="df">text</str>
+        </lst>
+    </initParams>
+
+    <requestHandler name="/update" class="solr.UpdateRequestHandler" />
+
+    <requestHandler name="/update/extract"
+                    startup="lazy"
+                    class="solr.extraction.ExtractingRequestHandler">
+        <lst name="defaults">
+            <str name="lowernames">true</str>
+            <str name="uprefix">ignored_</str>
+
+            <!-- capture link hrefs but ignore div attributes -->
+            <str name="captureAttr">true</str>
+            <str name="fmap.a">links</str>
+            <str name="fmap.div">ignored_</str>
+        </lst>
+    </requestHandler>
+
+    <requestHandler name="/analysis/field"
+                    startup="lazy"
+                    class="solr.FieldAnalysisRequestHandler" />
+
+    <requestHandler name="/analysis/document"
+                    class="solr.DocumentAnalysisRequestHandler"
+                    startup="lazy" />
+
+    <requestHandler name="/admin/ping" class="solr.PingRequestHandler">
+        <lst name="invariants">
+            <str name="q">solrpingquery</str>
+        </lst>
+        <lst name="defaults">
+            <str name="echoParams">all</str>
+        </lst>
+    </requestHandler>
+
+    <requestHandler name="/debug/dump" class="solr.DumpRequestHandler" >
+        <lst name="defaults">
+            <str name="echoParams">explicit</str>
+            <str name="echoHandler">true</str>
+        </lst>
+    </requestHandler>
+
+    <requestHandler name="/replication" class="solr.ReplicationHandler" />
+
+    <requestHandler name="/suggest" class="org.apache.solr.handler.component.SearchHandler">
+        <lst name="defaults">
+            <str name="spellcheck">true</str>
+            <str name="spellcheck.dictionary">suggest</str>
+            <str name="spellcheck.onlyMorePopular">true</str>
+            <str name="spellcheck.count">5</str>
+            <str name="spellcheck.collate">true</str>
+        </lst>
+        <arr name="components">
+            <str>suggest</str>
+        </arr>
+    </requestHandler>
+
+    <searchComponent name="spellcheck" class="solr.SpellCheckComponent">
+        <str name="queryAnalyzerFieldType">textSpell</str>
+
+        <lst name="spellchecker">
+            <str name="name">default</str>
+            <str name="field">name</str>
+            <str name="classname">solr.DirectSolrSpellChecker</str>
+            <str name="distanceMeasure">internal</str>
+            <float name="accuracy">0.5</float>
+            <int name="maxEdits">2</int>
+            <int name="minPrefix">1</int>
+            <int name="maxInspections">5</int>
+            <int name="minQueryLength">4</int>
+            <float name="maxQueryFrequency">0.01</float>
+        </lst>
+
+        <lst name="spellchecker">
+            <str name="name">wordbreak</str>
+            <str name="classname">solr.WordBreakSolrSpellChecker</str>
+            <str name="field">name</str>
+            <str name="combineWords">true</str>
+            <str name="breakWords">true</str>
+            <int name="maxChanges">10</int>
+        </lst>
+
+        <lst name="spellchecker">
+            <str name="name">suggest</str>
+            <str name="classname">org.apache.solr.spelling.suggest.Suggester</str>
+            <str name="lookupImpl">org.apache.solr.spelling.suggest.tst.TSTLookup</str>
+            <str name="field">text</str>  <!-- the indexed field to derive suggestions from -->
+            <float name="threshold">0.005</float>
+            <str name="buildOnCommit">true</str>
+        </lst>
+    </searchComponent>
+
+    <searchComponent name="suggest" class="solr.SpellCheckComponent">
+        <lst name="spellchecker">
+            <str name="name">suggest</str>
+            <str name="classname">org.apache.solr.spelling.suggest.Suggester</str>
+            <str name="lookupImpl">org.apache.solr.spelling.suggest.tst.TSTLookupFactory</str>
+            <str name="field">text_plain</str>  <!-- the indexed field to derive suggestions from -->
+            <float name="threshold">0.001</float>
+            <str name="buildOnCommit">true</str>
+        </lst>
+    </searchComponent>
+
+    <queryResponseWriter name="json" class="solr.JSONResponseWriter">
+        <str name="content-type">text/plain; charset=UTF-8</str>
+    </queryResponseWriter>
+
+    <admin>
+        <defaultQuery>*:*</defaultQuery>
+    </admin>
+
+</config>

--- a/conf/stopwords.txt
+++ b/conf/stopwords.txt
@@ -1,0 +1,14 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/conf/synonyms.txt
+++ b/conf/synonyms.txt
@@ -1,0 +1,29 @@
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#-----------------------------------------------------------------------
+#some test synonym mappings unlikely to appear in real input text
+aaafoo => aaabar
+bbbfoo => bbbfoo bbbbar
+cccfoo => cccbar cccbaz
+fooaaa,baraaa,bazaaa
+
+# Some synonym groups specific to this example
+GB,gib,gigabyte,gigabytes
+MB,mib,megabyte,megabytes
+Television, Televisions, TV, TVs
+#notice we use "gib" instead of "GiB" so any WordDelimiterFilter coming
+#after us won't split it into two words.
+
+# Synonym mappings can be used for spelling correction too
+pixima => pixma
+

--- a/src/Solr/Indexer/IndexField.php
+++ b/src/Solr/Indexer/IndexField.php
@@ -67,7 +67,7 @@ class IndexField
      * @param string $textFieldSuffix
      * @return string
      */
-    private function getFieldNameWithTextFieldSuffix(string $textFieldSuffix)
+    private function getFieldNameWithTextFieldSuffix($textFieldSuffix)
     {
         $transportObject = new Transport(
             [

--- a/src/Solr/Indexer/IndexField.php
+++ b/src/Solr/Indexer/IndexField.php
@@ -45,7 +45,7 @@ class IndexField
         return new self($this->attribute, $this->eventDispatcher, $forSorting);
     }
 
-    public function getFieldName()
+    public function getFieldName($forFullMatch = false)
     {
         $transportObject = new Transport(array(
             'fieldname' => '',
@@ -66,6 +66,9 @@ class IndexField
                     return $this->attribute->getAttributeCode() . '_f';
 
                 case Attribute::BACKEND_TYPE_TEXT:
+                    if ($forFullMatch) {
+                        return $this->attribute->getAttributeCode() . '_t_ns';
+                    }
                     return $this->attribute->getAttributeCode() . '_t';
 
                 case Attribute::BACKEND_TYPE_INT:
@@ -75,15 +78,18 @@ class IndexField
                     // fallthrough intended
                 case Attribute::BACKEND_TYPE_VARCHAR:
                 default:
-                    return ($this->forSorting) ? $this->attribute->getAttributeCode() . '_s' : $this->attribute->getAttributeCode() . '_t';
+                    if ($this->forSorting) {
+                        return $this->attribute->getAttributeCode() . '_s';
+                    }
+                    if ($forFullMatch) {
+                        return $this->attribute->getAttributeCode() . '_t_ns';
+                    }
+                    return $this->attribute->getAttributeCode() . '_t';
             }
         } else {
             switch ($this->attribute->getBackendType()) {
                 case Attribute::BACKEND_TYPE_DECIMAL:
                     return $this->attribute->getAttributeCode() . '_f_mv';
-
-                case Attribute::BACKEND_TYPE_TEXT:
-                    return $this->attribute->getAttributeCode() . '_t_mv';
 
                 case Attribute::BACKEND_TYPE_INT:
                     if ($this->attribute->getFacetType() != Attribute::FACET_TYPE_SELECT) {
@@ -91,7 +97,11 @@ class IndexField
                     }
                 // fallthrough intended
                 case Attribute::BACKEND_TYPE_VARCHAR:
+                case Attribute::BACKEND_TYPE_TEXT:
                 default:
+                    if ($forFullMatch) {
+                        return $this->attribute->getAttributeCode() . '_t_ns_mv';
+                    }
                     return $this->attribute->getAttributeCode() . '_t_mv';
             }
         }

--- a/src/Solr/Indexer/ProductIndexer.php
+++ b/src/Solr/Indexer/ProductIndexer.php
@@ -403,8 +403,7 @@ class ProductIndexer implements Indexer
 
             $indexField = new IndexField($attribute, $this->eventDispatcher);
             $fieldName = $indexField->getFieldName();
-            $fieldNameForFullMatch = $indexField->getFieldName(true);
-            $useFullMatchField = $fieldNameForFullMatch != $fieldName;
+            $fieldNameForFullMatch = $indexField->getFieldNameForFullMatch();
 
             $solrBoost = floatval($attribute->getSolrBoost());
             if ($solrBoost != 1) {
@@ -415,9 +414,7 @@ class ProductIndexer implements Indexer
                 && $value = $product->getSearchableAttributeValue($attribute)
             ) {
                 $productData->setData($fieldName, $value);
-                if ($useFullMatchField) {
-                    $productData->setData($fieldNameForFullMatch, $value);
-                }
+                $productData->setData($fieldNameForFullMatch, $value);
 
                 if (strstr($fieldName, '_t') == true && $attribute->getUsedForSortBy()) {
                     $productData->setData(

--- a/src/Solr/Indexer/ProductIndexer.php
+++ b/src/Solr/Indexer/ProductIndexer.php
@@ -403,6 +403,8 @@ class ProductIndexer implements Indexer
 
             $indexField = new IndexField($attribute, $this->eventDispatcher);
             $fieldName = $indexField->getFieldName();
+            $fieldNameForFullMatch = $indexField->getFieldName(true);
+            $useFullMatchField = $fieldNameForFullMatch != $fieldName;
 
             $solrBoost = floatval($attribute->getSolrBoost());
             if ($solrBoost != 1) {
@@ -413,6 +415,9 @@ class ProductIndexer implements Indexer
                 && $value = $product->getSearchableAttributeValue($attribute)
             ) {
                 $productData->setData($fieldName, $value);
+                if ($useFullMatchField) {
+                    $productData->setData($fieldNameForFullMatch, $value);
+                }
 
                 if (strstr($fieldName, '_t') == true && $attribute->getUsedForSortBy()) {
                     $productData->setData(

--- a/src/Solr/Query/SearchQueryBuilder.php
+++ b/src/Solr/Query/SearchQueryBuilder.php
@@ -161,10 +161,17 @@ final class SearchQueryBuilder extends AbstractQueryBuilder
                 if ($attribute->getIsSearchable() == 1) {
 
                     $fieldName = $this->getFieldName($attribute);
+                    $fieldNameForFullMatch = $this->getFieldName($attribute, false, true);
 
                     if (strstr($fieldName, '_f') == false) {
 
                         $boost = '^' . $this->getNormalizedBoost(floatval($attribute->getSolrBoost()));
+                        $boostForFullMatch = '';
+                        $useFieldForFullMatch = $fieldNameForFullMatch != $fieldName;
+                        if ($useFieldForFullMatch) {
+                            $boostForFullMatch = $boost;
+                            $boost = '^' . $this->getNormalizedBoost(floatval($attribute->getSolrBoost()) / 100);
+                        }
 
                         if ($this->broaden) {
 
@@ -172,34 +179,52 @@ final class SearchQueryBuilder extends AbstractQueryBuilder
                                 $queryText .= ($isFirst) ? '' : ' OR ';
                                 $queryText .= $fieldName . ':"' . trim($value) . '"~100' . $boost;
                                 $isFirst = false;
+                                if ($useFieldForFullMatch) {
+                                    $queryText .= ' OR ' . $fieldNameForFullMatch . ':"' . trim($value) . '"~100' . $boostForFullMatch;
+                                }
                             }
 
                         } else {
                             $queryText .= ($isFirst) ? '' : ' OR ';
                             $queryText .= $fieldName . ':"' . trim($searchValue) . '"~100' . $boost;
                             $isFirst = false;
+                            if ($useFieldForFullMatch) {
+                                $queryText .= ' OR ' . $fieldNameForFullMatch . ':"' . trim($searchValue) . '"~100' . $boostForFullMatch;
+                            }
                         }
                     }
                 }
             }
 
             $fieldName = 'category_name_t_mv';
+            $fieldNameForFullMatch = 'category_name_t_ns_mv';
 
             $categoriesPriority = floatval($this->getResultsConfig()->getPriorityCategories());
             if ($categoriesPriority > 0) {
                 $boost = '^' . $this->getNormalizedBoost($categoriesPriority);
+                $boostForFullMatch = '';
+                $useFieldForFullMatch = $fieldNameForFullMatch != $fieldName;
+                if ($useFieldForFullMatch) {
+                    $boostForFullMatch = $boost;
+                    $boost = '^' . $this->getNormalizedBoost($categoriesPriority / 100);
+                }
 
                 if ($this->broaden) {
 
                     foreach ($searchValue as $value) {
                         $queryText .= ($isFirst) ? '' : ' OR ';
                         $queryText .= $fieldName . ':"' . trim($value) . '"~100' . $boost;
-                        $isFirst = false;
+                        if ($useFieldForFullMatch) {
+                            $queryText .= ' OR ' . $fieldNameForFullMatch . ':"' . trim($value) . '"~100' . $boostForFullMatch;
+                        }
                     }
 
                 } else {
                     $queryText .= ($isFirst) ? '' : ' OR ';
                     $queryText .= $fieldName . ':"' . trim($searchValue) . '"~100' . $boost;
+                    if ($useFieldForFullMatch) {
+                        $queryText .= ' OR ' . $fieldNameForFullMatch . ':"' . trim($searchValue) . '"~100' . $boostForFullMatch;
+                    }
                 }
             }
         }
@@ -217,12 +242,13 @@ final class SearchQueryBuilder extends AbstractQueryBuilder
     /**
      * @param Attribute $attribute
      * @param bool $forSorting
+     * @param bool $forFullMatch
      * @return string
      */
-    private function getFieldName(Attribute $attribute, $forSorting = false)
+    private function getFieldName(Attribute $attribute, $forSorting = false, $forFullMatch = false)
     {
         $indexField = new IndexField($attribute, $this->getEventDispatcher());
-        return $indexField->getFieldName();
+        return $indexField->getFieldName($forFullMatch);
     }
 
     /**

--- a/src/Solr/Query/SearchQueryBuilder.php
+++ b/src/Solr/Query/SearchQueryBuilder.php
@@ -161,7 +161,7 @@ final class SearchQueryBuilder extends AbstractQueryBuilder
                 if ($attribute->getIsSearchable() == 1) {
 
                     $fieldName = $this->getFieldName($attribute);
-                    $fieldNameForFullMatch = $this->getFieldName($attribute, false, true);
+                    $fieldNameForFullMatch = $this->getFieldNameForFullMatch($attribute);
 
                     if (strstr($fieldName, '_f') == false) {
 
@@ -241,14 +241,22 @@ final class SearchQueryBuilder extends AbstractQueryBuilder
 
     /**
      * @param Attribute $attribute
-     * @param bool $forSorting
-     * @param bool $forFullMatch
      * @return string
      */
-    private function getFieldName(Attribute $attribute, $forSorting = false, $forFullMatch = false)
+    private function getFieldName(Attribute $attribute)
     {
         $indexField = new IndexField($attribute, $this->getEventDispatcher());
-        return $indexField->getFieldName($forFullMatch);
+        return $indexField->getFieldName();
+    }
+
+    /**
+     * @param Attribute $attribute
+     * @return string
+     */
+    private function getFieldNameForFullMatch(Attribute $attribute)
+    {
+        $indexField = new IndexField($attribute, $this->getEventDispatcher());
+        return $indexField->getFieldNameForFullMatch();
     }
 
     /**

--- a/test/Solr/Query/SearchQueryBuilderTest.php
+++ b/test/Solr/Query/SearchQueryBuilderTest.php
@@ -104,7 +104,7 @@ class SearchQueryBuilderTest extends PHPUnit_Framework_TestCase
             ],
             'alternative' => [1, ResultConfigBuilder::alternativeConfig()->build(), FuzzyConfigBuilder::inactiveConfig()->build(),
                 FilterQueryBuilder::noFilterQueryBuilder($defaultResultConfig, $attributeRepositoryStub, $defaultStoreId), PaginationStub::alternativePagination(), new SearchString('"foo bar"'),
-                new Query(1, 'attribute1_t:""foo bar""~100^0 OR attribute2_t:""foo bar""~100^0 OR category_name_t_mv:""foo bar""~100^1', 0, 24, [
+                new Query(1, 'attribute1_t:""foo bar""~100^0 OR attribute1_t_ns:""foo bar""~100^0 OR attribute2_t:""foo bar""~100^0 OR attribute2_t_ns:""foo bar""~100^0 OR category_name_t_mv:""foo bar""~100^0.01000000000000000021 OR category_name_t_ns_mv:""foo bar""~100^1', 0, 24, [
                         'q.op' => ResultsConfig::SEARCH_OPERATOR_OR,
                         'fq' => "content_type:product AND store_id:1 AND is_visible_in_search_i:1",
                         'sort' => 'attribute1_s desc',


### PR DESCRIPTION
We do this by creating additional text fields which won't be split, so they only match if the full word matches. The new text fields get prioritizes 100 times higher than the old fields which also match parts of words.
Additionally, I have added the solr configuration to this repository. I will remove them from the solr_magento1 repo with the next version.