### PR TITLE
Increase facet limit to 10000

### DIFF
--- a/src/Solr/Query/AbstractParamsBuilder.php
+++ b/src/Solr/Query/AbstractParamsBuilder.php
@@ -117,6 +117,7 @@ abstract class AbstractParamsBuilder implements ParamsBuilder, HasFilter, HasPag
             'facet.sort' => 'true',
             'facet.mincount' => '1',
             'facet.field' => $this->getFacetFieldCodes(),
+            'facet.limit' => 10000,
             'defType' => 'edismax',
             'mm' => '1',
         );

--- a/test/Solr/Query/SearchQueryBuilderTest.php
+++ b/test/Solr/Query/SearchQueryBuilderTest.php
@@ -78,6 +78,7 @@ class SearchQueryBuilderTest extends PHPUnit_Framework_TestCase
             'stats' => 'true',
             'stats.field' => ['price_f'],
             'facet.range' => 'price_f',
+            'facet.limit' => 10000,
             'f.price_f.facet.range.start' => 0,
             'f.price_f.facet.range.end' => ResultConfigBuilder::DEFAULT_MAX_PRICE,
             'f.price_f.facet.range.gap' => ResultConfigBuilder::DEFAULT_STEP_SIZE,


### PR DESCRIPTION
The default limit is 100 which means that only the top 100 values are returned
for filters.