### PR TITLE
Restore PHP 5.6 compatibility by removing return type

### DIFF
--- a/src/Solr/Indexer/ProductIndexer.php
+++ b/src/Solr/Indexer/ProductIndexer.php
@@ -636,7 +636,10 @@ class ProductIndexer implements Indexer
         return $this->_getResource()->checkSwapCoresConfiguration($restrictToStoreIds);
     }
 
-    private function getProgressDispatcher(): ProgressDispatcher
+    /**
+     * @return ProgressDispatcher
+     */
+    private function getProgressDispatcher()
     {
         if ($this->progressDispatcher === null) {
             $this->progressDispatcher = new ProgressDispatcher($this->progressHandlers);


### PR DESCRIPTION
Necessary for the Magento 1 module